### PR TITLE
add budget usage and budget rules to Postman collection

### DIFF
--- a/postman/Amazon_Ads_API.postman_collection.json
+++ b/postman/Amazon_Ads_API.postman_collection.json
@@ -1,10 +1,9 @@
 {
 	"info": {
-		"_postman_id": "6d5100fe-e1c8-43c6-abe8-982125165433",
+		"_postman_id": "dadc4fb5-e58a-46dd-ae42-a071838044d7",
 		"name": "Amazon Ads API",
 		"description": "# Amazon Ads API Postman collection\n\nThis collection includes commonly used endpoints for the Amazon Ads API. The collection also includes pre- and post-request scripts to automate management of auth credentials.\n\nVisit the [Amazon Ads advanced tools center](https://advertising.amazon.com/API/docs/en-us/) for API documentation.\n\n## Setup\n\nTo use this collection, you will need credentials for the Amazon Ads API. For information about acquiring credentials, see the [onboarding overview for the Amazon Ads API](https://advertising.amazon.com/API/docs/en-us/onboarding/overview).\n\nFind setup instructions in the Amazon Ads advanced tools center for:\n\n- [New users of the Amazon Ads API](https://advertising.amazon.com/API/docs/en-us/getting-started/using-postman-collection)\n- [Users with an existing refresh token](https://advertising.amazon.com/API/docs/en-us/tutorials/postman) \n\n## Issues and support\n\nFor technical support for the Amazon Ads API, see [Technical support](https://advertising.amazon.com/API/docs/en-us/info/support) in the Amazon Ads advanced tools center.\n\nTo report a bug or suggest an improvement relating to this collection or the documentation, [create an issue](https://github.com/amzn/ads-advanced-tools-docs/issues/new/choose).",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "25489918"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
@@ -377,13 +376,13 @@
 							}
 						],
 						"url": {
-							"raw": "{{api_url}}/sb/beta/campaigns/list",
+							"raw": "{{api_url}}/sb/v4/campaigns/list",
 							"host": [
 								"{{api_url}}"
 							],
 							"path": [
 								"sb",
-								"beta",
+								"v4",
 								"campaigns",
 								"list"
 							]
@@ -417,13 +416,13 @@
 									}
 								],
 								"url": {
-									"raw": "{{api_url}}/sb/beta/campaigns/list",
+									"raw": "{{api_url}}/sb/v4/campaigns/list",
 									"host": [
 										"{{api_url}}"
 									],
 									"path": [
 										"sb",
-										"beta",
+										"v4",
 										"campaigns",
 										"list"
 									]
@@ -439,7 +438,7 @@
 								},
 								{
 									"key": "Date",
-									"value": "Thu, 03 Nov 2022 15:16:08 GMT"
+									"value": "Tue, 28 Mar 2023 19:10:37 GMT"
 								},
 								{
 									"key": "Content-Type",
@@ -447,7 +446,7 @@
 								},
 								{
 									"key": "Content-Length",
-									"value": "837"
+									"value": "641"
 								},
 								{
 									"key": "Connection",
@@ -455,31 +454,31 @@
 								},
 								{
 									"key": "x-amz-rid",
-									"value": "16CT4FY9CZ2WQ8C7G7AG"
+									"value": "X6SM1M6EFDN44C60NQC9"
 								},
 								{
 									"key": "x-amzn-RequestId",
-									"value": "5b2ebc85-fc67-49f5-8555-309400b51a9a"
+									"value": "e1bab0ca-bf73-43c7-a7dc-02b1ad625770"
 								},
 								{
 									"key": "x-amzn-Remapped-x-amzn-RequestId",
-									"value": "bd4b9db5-2f90-4dbe-afbe-9a15e639b8e6"
+									"value": "28358208-795d-4ee6-8a2f-755335addec5"
 								},
 								{
 									"key": "x-amzn-Remapped-Content-Length",
-									"value": "837"
+									"value": "641"
 								},
 								{
 									"key": "x-amz-apigw-id",
-									"value": "bB8wfFYsoAMF44A="
+									"value": "CgZDJEtnoAMFzbA="
 								},
 								{
 									"key": "X-Amzn-Trace-Id",
-									"value": "Root=1-6363db38-7c4802ebc190c0f4c81d535e"
+									"value": "Root=1-64233bad-d65ff4f637ef95198ccb4e1c"
 								},
 								{
 									"key": "x-amzn-Remapped-Date",
-									"value": "Thu, 03 Nov 2022 15:16:08 GMT"
+									"value": "Tue, 28 Mar 2023 19:10:36 GMT"
 								},
 								{
 									"key": "Vary",
@@ -491,7 +490,7 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n    \"campaigns\": [\n        {\n            \"bidding\": {\n                \"bidOptimization\": true,\n                \"bidOptimizationStrategy\": \"MAXIMIZE_IMMEDIATE_SALES\"\n            },\n            \"brandEntityId\": \"ENTITY1GY02L4M2U9FK\",\n            \"budget\": 10,\n            \"budgetType\": \"DAILY\",\n            \"campaignId\": \"177829948461538\",\n            \"isMultiAdGroupsEnabled\": true,\n            \"name\": \"Test v4 campaign 3\",\n            \"productLocation\": \"SOLD_ON_AMAZON\",\n            \"ruleBasedBudget\": {\n                \"applicableRuleId\": \"cfb9e95c-8dd7-413e-853e-e44d07d44f3c\",\n                \"applicableRuleName\": \"My budget rule\",\n                \"isProcessing\": false,\n                \"value\": 11\n            },\n            \"startDate\": \"2022-10-20\",\n            \"state\": \"PAUSED\"\n        },\n        {\n            \"bidding\": {\n                \"bidOptimization\": true,\n                \"bidOptimizationStrategy\": \"MAXIMIZE_IMMEDIATE_SALES\"\n            },\n            \"brandEntityId\": \"ENTITY1GY02L4M2U9FK\",\n            \"budget\": 10,\n            \"budgetType\": \"DAILY\",\n            \"campaignId\": \"50253512169230\",\n            \"isMultiAdGroupsEnabled\": true,\n            \"name\": \"Test v4 campaign 4\",\n            \"productLocation\": \"SOLD_ON_AMAZON\",\n            \"startDate\": \"2022-10-20\",\n            \"state\": \"PAUSED\"\n        }\n    ],\n    \"totalCount\": 2\n}"
+							"body": "{\n    \"campaigns\": [\n        {\n            \"bidding\": {\n                \"bidOptimization\": true,\n                \"bidOptimizationStrategy\": \"MAXIMIZE_IMMEDIATE_SALES\"\n            },\n            \"brandEntityId\": \"ENTITY21DWFJV45CH71\",\n            \"budget\": 50,\n            \"budgetType\": \"DAILY\",\n            \"campaignId\": \"38789817437281\",\n            \"isMultiAdGroupsEnabled\": true,\n            \"name\": \"Campaign - 2/20/2023 22:26:18\",\n            \"startDate\": \"2023-02-20\",\n            \"state\": \"ENABLED\"\n        },\n        {\n            \"bidding\": {\n                \"bidOptimization\": true,\n                \"bidOptimizationStrategy\": \"MAXIMIZE_IMMEDIATE_SALES\"\n            },\n            \"brandEntityId\": \"ENTITY21DWFJV45CH71\",\n            \"budget\": 100,\n            \"budgetType\": \"DAILY\",\n            \"campaignId\": \"194584775574615\",\n            \"isMultiAdGroupsEnabled\": true,\n            \"name\": \"Campaign - 3/8/2023 16:39:05\",\n            \"startDate\": \"2023-03-08\",\n            \"state\": \"ENABLED\"\n        }\n    ],\n    \"totalCount\": 2\n}"
 						}
 					]
 				},
@@ -16294,6 +16293,6475 @@
 					"response": []
 				}
 			]
+		},
+		{
+			"name": "Budget rules",
+			"item": [
+				{
+					"name": "SP",
+					"item": [
+						{
+							"name": "Create budget rules",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"/* Save ruleId to environment */",
+											"if(responseCode.code === 207) {",
+											"var response = JSON.parse(responseBody);",
+											"var budgetRuleId = response.responses[0].ruleId",
+											"postman.clearEnvironmentVariable(\"budgetRuleId\");",
+											"postman.setEnvironmentVariable(\"budgetRuleId\", budgetRuleId); ",
+											"    console.log(\"ruleId is \" + budgetRuleId);",
+											"} else {",
+											"    console.log(responseBody);",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									},
+									{
+										"key": "",
+										"value": "",
+										"type": "default",
+										"disabled": true
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"budgetRulesDetails\": [\n    {\n      \"name\": \"ACOS < 20%\",\n      \"ruleType\": \"PERFORMANCE\",\n      \"duration\": {\n        \"dateRangeTypeRuleDuration\": {\n          \"startDate\": \"20230301\",\n          \"endDate\": \"20230430\"\n        }\n      },\n      \"recurrence\": {\n        \"type\": \"DAILY\"\n      },\n      \"budgetIncreaseBy\": {\n        \"type\": \"PERCENT\",\n        \"value\": 20\n      },\n      \"performanceMeasureCondition\": {\n        \"metricName\": \"ACOS\",\n        \"threshold\": 20,\n        \"comparisonOperator\": \"LESS_THAN_OR_EQUAL_TO\"\n      }\n    }\n  ]\n}"
+								},
+								"url": {
+									"raw": "{{api_url}}/sp/budgetRules",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sp",
+										"budgetRules"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Event-based, scheduled, daily rule",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"budgetRulesDetails\": [\n    {\n      \"name\": \"Easter 25%\",\n      \"ruleType\": \"SCHEDULE\",\n      \"duration\": {\n        \"eventTypeRuleDuration\": {\n          \"eventId\": \"{{eventId}}\"\n        }\n      },\n      \"recurrence\": {\n        \"type\": \"DAILY\"\n      },\n      \"budgetIncreaseBy\": {\n        \"type\": \"PERCENT\",\n        \"value\": 25\n      }\n    }\n  ]\n}"
+										},
+										"url": {
+											"raw": "{{api_url}}/sp/budgetRules",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sp",
+												"budgetRules"
+											]
+										}
+									},
+									"status": "Multi-Status (WebDAV) (RFC 4918)",
+									"code": 207,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Mon, 20 Feb 2023 18:25:06 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "7FGJM8PBRGWBHHCJ9A7V"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "8adfba60-8de4-4d88-a4e8-ad169fd0a0fc"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "7FGJM8PBRGWBHHCJ9A7V"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Mon, 20 Feb 2023 18:25:06 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "ApoodEAloAMFrqQ="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f3bb02-effc633ece845ea3d401b5cd"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Mon, 20 Feb 2023 18:25:06 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"responses\": [\n        {\n            \"associatedCampaignIds\": null,\n            \"code\": \"Ok\",\n            \"details\": \"Budget rule created\",\n            \"ruleId\": \"98ef675d-e436-4506-85c9-c60345318e08\"\n        }\n    ]\n}"
+								},
+								{
+									"name": "Scheduled, weekly rule",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"budgetRulesDetails\": [\n    {\n      \"name\": \"Spring 35%\",\n      \"ruleType\": \"SCHEDULE\",\n      \"duration\": {\n        \"dateRangeTypeRuleDuration\": {\n          \"startDate\": \"20230301\",\n          \"endDate\": \"20230430\"\n        }\n      },\n      \"recurrence\": {\n        \"type\": \"WEEKLY\",\n        \"daysOfWeek\": [\n          \"MONDAY\",\"WEDNESDAY\"\n        ]\n      },\n      \"budgetIncreaseBy\": {\n        \"type\": \"PERCENT\",\n        \"value\": 35\n      }\n    }\n  ]\n}"
+										},
+										"url": {
+											"raw": "{{api_url}}/sp/budgetRules",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sp",
+												"budgetRules"
+											]
+										}
+									},
+									"status": "Multi-Status (WebDAV) (RFC 4918)",
+									"code": 207,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Mon, 20 Feb 2023 18:34:20 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "9T4SW0E2N8HP8YASBQN6"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "0902e47f-7d07-4ea4-9aac-ab175c3cf6f7"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "9T4SW0E2N8HP8YASBQN6"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Mon, 20 Feb 2023 18:34:20 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "App-_F-HoAMFYkA="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f3bd2c-0cc919fd3e03c873f606f4c1"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Mon, 20 Feb 2023 18:34:20 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"responses\": [\n        {\n            \"associatedCampaignIds\": null,\n            \"code\": \"Ok\",\n            \"details\": \"Budget rule created\",\n            \"ruleId\": \"30db13f7-360e-475e-ae76-f779c2303749\"\n        }\n    ]\n}"
+								},
+								{
+									"name": "Performance-based rule",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"budgetRulesDetails\": [\n    {\n      \"name\": \"ACOS < 20%\",\n      \"ruleType\": \"PERFORMANCE\",\n      \"duration\": {\n        \"dateRangeTypeRuleDuration\": {\n          \"startDate\": \"20230301\",\n          \"endDate\": \"20230430\"\n        }\n      },\n      \"recurrence\": {\n        \"type\": \"DAILY\"\n      },\n      \"budgetIncreaseBy\": {\n        \"type\": \"PERCENT\",\n        \"value\": 20\n      },\n      \"performanceMeasureCondition\": {\n        \"metricName\": \"ACOS\",\n        \"threshold\": 20,\n        \"comparisonOperator\": \"LESS_THAN_OR_EQUAL_TO\"\n      }\n    }\n  ]\n}"
+										},
+										"url": {
+											"raw": "{{api_url}}/sp/budgetRules",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sp",
+												"budgetRules"
+											]
+										}
+									},
+									"status": "Multi-Status (WebDAV) (RFC 4918)",
+									"code": 207,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Mon, 20 Feb 2023 18:41:18 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "34B53KRFCZJA04N33BH4"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "1f22d6bc-5a37-43c3-b886-30ac906a50ee"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "34B53KRFCZJA04N33BH4"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Mon, 20 Feb 2023 18:41:18 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "AprARGXpoAMFWmA="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f3bece-6b5201a37d924b1f972b285e"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Mon, 20 Feb 2023 18:41:17 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"responses\": [\n        {\n            \"associatedCampaignIds\": null,\n            \"code\": \"Ok\",\n            \"details\": \"Budget rule created\",\n            \"ruleId\": \"22cbf410-cab5-434c-bc79-540e0ed8e90c\"\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "Associate budget rules to campaign",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									},
+									{
+										"key": "",
+										"value": "",
+										"type": "default",
+										"disabled": true
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"budgetRuleIds\": [\n    \"{{budgetRuleId}}\"\n  ]\n}"
+								},
+								"url": {
+									"raw": "{{api_url}}/sp/campaigns/:campaignId/budgetRules",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sp",
+										"campaigns",
+										":campaignId",
+										"budgetRules"
+									],
+									"variable": [
+										{
+											"key": "campaignId",
+											"value": "{{campaignId}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"budgetRuleIds\": [\n    \"{{budgetRuleId}}\"\n  ]\n}"
+										},
+										"url": {
+											"raw": "{{api_url}}/sp/campaigns/:campaignId/budgetRules",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sp",
+												"campaigns",
+												":campaignId",
+												"budgetRules"
+											],
+											"query": [
+												{
+													"key": "nextToken",
+													"value": null,
+													"disabled": true
+												}
+											],
+											"variable": [
+												{
+													"key": "campaignId",
+													"value": "{{campaignId}}"
+												}
+											]
+										}
+									},
+									"status": "Multi-Status (WebDAV) (RFC 4918)",
+									"code": 207,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:18:21 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "113"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "1FC9NEW0WKK67QKQZ90P"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "bda2830f-a740-4df8-a914-4d0af68b225a"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "1FC9NEW0WKK67QKQZ90P"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:18:21 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "113"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq2vmHXcIAMFe5w="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f437fd-b5b56a323078a7fed94b5976"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:18:21 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"responses\": [\n        {\n            \"code\": \"Ok\",\n            \"details\": \"Budget rule associated\",\n            \"ruleId\": \"9b320ccc-6f06-4662-a86d-2fab422ccee8\"\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "Get recommended events",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"/*Save eventId from first object to environment*/",
+											"",
+											"if (responseCode.code === 200) {",
+											"    var response = JSON.parse(responseBody);",
+											"    if(!response.recommendedBudgetRuleEvents[0]) {",
+											"        console.info(\"No events were returned.\");",
+											"    } else {",
+											"        var eventId = response.recommendedBudgetRuleEvents[0].eventId",
+											"        postman.clearEnvironmentVariable(\"eventId\");",
+											"        postman.setEnvironmentVariable(\"eventId\", eventId); ",
+											"        console.log(\"eventId from first event object is \" + eventId);",
+											"    } ",
+											"} else {",
+											"    console.log(responseCode, responseBody);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/vnd.spbudgetrulesrecommendation.v3+json",
+										"type": "default"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"campaignId\":\"{{campaignId}}\"\n}"
+								},
+								"url": {
+									"raw": "{{api_url}}/sp/campaigns/budgetRules/recommendations",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sp",
+										"campaigns",
+										"budgetRules",
+										"recommendations"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/vnd.spbudgetrulesrecommendation.v3+json",
+												"type": "default"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"campaignId\":\"{{campaignId}}\"\n}"
+										},
+										"url": {
+											"raw": "{{api_url}}/sp/campaigns/budgetRules/recommendations",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sp",
+												"campaigns",
+												"budgetRules",
+												"recommendations"
+											],
+											"query": [
+												{
+													"key": "nextToken",
+													"value": null,
+													"disabled": true
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Mon, 20 Feb 2023 18:15:49 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "500"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "CN4N80ZRHE4ZN883X8H2"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "67e7c628-a00d-4a82-bfb9-8ed645b0812c"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "ApnRRHThIAMFe0A="
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f3b8d5-abcf439923d38a1c6bd9579c"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"recommendedBudgetRuleEvents\": [\n        {\n            \"endDate\": \"20230409\",\n            \"eventId\": \"c92869a2-fe6f-56ac-ba86-d08388396936\",\n            \"eventName\": \"Easter\",\n            \"startDate\": \"20230326\",\n            \"suggestedBudgetIncreasePercent\": 24\n        },\n        {\n            \"endDate\": \"20230515\",\n            \"eventId\": \"1b943597-d48e-5147-abd1-7ed20fcb693c\",\n            \"eventName\": \"Mother's Day\",\n            \"startDate\": \"20230511\",\n            \"suggestedBudgetIncreasePercent\": 0\n        },\n        {\n            \"endDate\": \"20230619\",\n            \"eventId\": \"553ddee0-8178-544b-a54a-f8918d21ad5f\",\n            \"eventName\": \"Father's Day\",\n            \"startDate\": \"20230611\",\n            \"suggestedBudgetIncreasePercent\": 38\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "All budget rules",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"/*Save budgetRuleId from first object to environment*/",
+											"",
+											"if (responseCode.code === 200) {",
+											"    var response = JSON.parse(responseBody);",
+											"    if(!response.budgetRulesForAdvertiserResponse[0]) {",
+											"        console.info(\"No rules were returned.\");",
+											"    } else {",
+											"        var budgetRuleId = response.budgetRulesForAdvertiserResponse[0].ruleId",
+											"        postman.clearEnvironmentVariable(\"budgetRuleId\");",
+											"        postman.setEnvironmentVariable(\"budgetRuleId\", budgetRuleId); ",
+											"        console.log(\"budgetRuleId from first rule object is \" + budgetRuleId);",
+											"    } ",
+											"} else {",
+											"    console.log(responseCode, responseBody);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									},
+									{
+										"key": "",
+										"value": "",
+										"type": "default",
+										"disabled": true
+									}
+								],
+								"url": {
+									"raw": "{{api_url}}/sp/budgetRules?pageSize=30",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sp",
+										"budgetRules"
+									],
+									"query": [
+										{
+											"key": "nextToken",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "pageSize",
+											"value": "30"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/sp/budgetRules?pageSize=30",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sp",
+												"budgetRules"
+											],
+											"query": [
+												{
+													"key": "nextToken",
+													"value": null,
+													"disabled": true
+												},
+												{
+													"key": "pageSize",
+													"value": "30"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Mon, 20 Feb 2023 16:56:49 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "1265"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "QPZYFNZADFJ36J42XPYZ"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "6d3c5945-b8a5-4c0a-b31d-f85609b4ae4a"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "QPZYFNZADFJ36J42XPYZ"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Mon, 20 Feb 2023 16:56:49 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "1265"
+										},
+										{
+											"key": "x-amzn-Remapped-Connection",
+											"value": "close"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "ApbssFA_IAMFV0w="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f3a651-107b2df163d3c25a450a8db7"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Mon, 20 Feb 2023 16:56:49 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"budgetRulesForAdvertiserResponse\": [\n        {\n            \"createdDate\": 1676912194576,\n            \"lastUpdatedDate\": 1676912194576,\n            \"ruleDetails\": {\n                \"budgetIncreaseBy\": {\n                    \"type\": \"PERCENT\",\n                    \"value\": 25\n                },\n                \"duration\": {\n                    \"dateRangeTypeRuleDuration\": {\n                        \"endDate\": \"20230228\",\n                        \"startDate\": \"20230220\"\n                    },\n                    \"eventTypeRuleDuration\": null\n                },\n                \"name\": \"Spring Budget Rule\",\n                \"performanceMeasureCondition\": {\n                    \"comparisonOperator\": \"GREATER_THAN_OR_EQUAL_TO\",\n                    \"metricName\": \"ROAS\",\n                    \"threshold\": 2\n                },\n                \"recurrence\": {\n                    \"daysOfWeek\": null,\n                    \"intraDaySchedule\": null,\n                    \"type\": \"DAILY\"\n                },\n                \"ruleType\": \"PERFORMANCE\"\n            },\n            \"ruleId\": \"f1eded08-af77-454a-b307-7783802657e2\",\n            \"ruleState\": \"ACTIVE\",\n            \"ruleStatus\": \"ACTIVE\",\n            \"ruleStatusDetails\": null\n        },\n        {\n            \"createdDate\": 1676912153402,\n            \"lastUpdatedDate\": 1676912153402,\n            \"ruleDetails\": {\n                \"budgetIncreaseBy\": {\n                    \"type\": \"PERCENT\",\n                    \"value\": 20\n                },\n                \"duration\": {\n                    \"dateRangeTypeRuleDuration\": null,\n                    \"eventTypeRuleDuration\": {\n                        \"endDate\": \"20230515\",\n                        \"eventId\": \"1b943597-d48e-5147-abd1-7ed20fcb693c\",\n                        \"eventName\": \"Mother's Day\",\n                        \"startDate\": \"20230511\"\n                    }\n                },\n                \"name\": \"Mother's Day Budget Rule\",\n                \"performanceMeasureCondition\": null,\n                \"recurrence\": {\n                    \"daysOfWeek\": null,\n                    \"intraDaySchedule\": null,\n                    \"type\": \"DAILY\"\n                },\n                \"ruleType\": \"SCHEDULE\"\n            },\n            \"ruleId\": \"c29298a0-0369-4146-8065-a73d33d51779\",\n            \"ruleState\": \"ACTIVE\",\n            \"ruleStatus\": \"PENDING_START\",\n            \"ruleStatusDetails\": null\n        }\n    ],\n    \"nextToken\": null\n}"
+								}
+							]
+						},
+						{
+							"name": "Update budget rules",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									},
+									{
+										"key": "",
+										"value": "",
+										"type": "default",
+										"disabled": true
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"budgetRulesDetails\": [\n    {\n      \"lastUpdatedDate\": null,\n      \"ruleDetails\": {\n        \"ruleType\": \"PERFORMANCE\",\n        \"name\": \"Spring Budget Rule - Updated\",\n        \"duration\": {\n          \"dateRangeTypeRuleDuration\": {\n            \"startDate\": \"20230220\",\n            \"endDate\": \"20230308\"\n          }\n        },\n        \"recurrence\": {\n          \"type\": \"DAILY\"\n        },\n        \"budgetIncreaseBy\": {\n          \"type\": \"PERCENT\",\n          \"value\": 75\n        },\n        \"performanceMeasureCondition\": {\n          \"metricName\": \"ROAS\",\n          \"comparisonOperator\": \"GREATER_THAN_OR_EQUAL_TO\",\n          \"threshold\": 2.0\n        }\n      },\n      \"ruleId\": \"{{budgetRuleId}}\",\n      \"ruleState\": \"ACTIVE\",\n      \"ruleStatus\": \"ACTIVE\",\n      \"ruleStatusDetails\": null\n    }\n  ]\n}"
+								},
+								"url": {
+									"raw": "{{api_url}}/sp/budgetRules",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sp",
+										"budgetRules"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Update rule state",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"budgetRulesDetails\": [\n    {\n      \"ruleId\": \"{{budgetRuleId}}\",\n      \"ruleState\": \"PAUSED\"\n    }\n  ]\n}"
+										},
+										"url": {
+											"raw": "{{api_url}}/sp/budgetRules",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sp",
+												"budgetRules"
+											]
+										}
+									},
+									"status": "Multi-Status (WebDAV) (RFC 4918)",
+									"code": 207,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Mon, 20 Feb 2023 17:14:40 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "154"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "7P345KQQCHNDVD1XXGTA"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "d79a1d7f-5011-4989-97d7-8d08ea6b9ebb"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "7P345KQQCHNDVD1XXGTA"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Mon, 20 Feb 2023 17:14:40 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "154"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "ApeT_Gm5IAMFj2w="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f3aa80-544ed52fccd1995dd519aa75"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Mon, 20 Feb 2023 17:14:39 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"responses\": [\n        {\n            \"associatedCampaignIds\": [\n                \"102028944323821\"\n            ],\n            \"code\": \"Ok\",\n            \"details\": \"Budget rule updated\",\n            \"ruleId\": \"f1eded08-af77-454a-b307-7783802657e2\"\n        }\n    ]\n}"
+								},
+								{
+									"name": "Update name, end date, increase value",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"budgetRulesDetails\": [\n    {\n      \"lastUpdatedDate\": null,\n      \"ruleDetails\": {\n        \"ruleType\": \"PERFORMANCE\",\n        \"name\": \"Spring Budget Rule - Updated\",\n        \"duration\": {\n          \"dateRangeTypeRuleDuration\": {\n            \"startDate\": \"20230220\",\n            \"endDate\": \"20230308\"\n          }\n        },\n        \"recurrence\": {\n          \"type\": \"DAILY\"\n        },\n        \"budgetIncreaseBy\": {\n          \"type\": \"PERCENT\",\n          \"value\": 75\n        },\n        \"performanceMeasureCondition\": {\n          \"metricName\": \"ROAS\",\n          \"comparisonOperator\": \"GREATER_THAN_OR_EQUAL_TO\",\n          \"threshold\": 2.0\n        }\n      },\n      \"ruleId\": \"{{budgetRuleId}}\",\n      \"ruleState\": \"ACTIVE\",\n      \"ruleStatus\": \"ACTIVE\",\n      \"ruleStatusDetails\": null\n    }\n  ]\n}"
+										},
+										"url": {
+											"raw": "{{api_url}}/sp/budgetRules",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sp",
+												"budgetRules"
+											]
+										}
+									},
+									"status": "Multi-Status (WebDAV) (RFC 4918)",
+									"code": 207,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Mon, 20 Feb 2023 18:14:34 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "154"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "EBEDH0821H74K4F2QGMD"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "a1049984-0c37-4bf8-a49e-4a7eca0965e3"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "EBEDH0821H74K4F2QGMD"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Mon, 20 Feb 2023 18:14:34 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "154"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "ApnFjFGqIAMF4Fg="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f3b88a-26b3c2d8534d987e11cd82bb"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Mon, 20 Feb 2023 18:14:33 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"responses\": [\n        {\n            \"associatedCampaignIds\": [\n                \"102028944323821\"\n            ],\n            \"code\": \"Ok\",\n            \"details\": \"Budget rule updated\",\n            \"ruleId\": \"f1eded08-af77-454a-b307-7783802657e2\"\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "Disassociate budget rule from campaign",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									}
+								],
+								"url": {
+									"raw": "{{api_url}}/sp/campaigns/:campaignId/budgetRules/:budgetRuleId",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sp",
+										"campaigns",
+										":campaignId",
+										"budgetRules",
+										":budgetRuleId"
+									],
+									"variable": [
+										{
+											"key": "campaignId",
+											"value": "{{campaignId}}"
+										},
+										{
+											"key": "budgetRuleId",
+											"value": "{{budgetRuleId}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/sp/campaigns/:campaignId/budgetRules/:budgetRuleId",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sp",
+												"campaigns",
+												":campaignId",
+												"budgetRules",
+												":budgetRuleId"
+											],
+											"variable": [
+												{
+													"key": "campaignId",
+													"value": "{{campaignId}}"
+												},
+												{
+													"key": "budgetRuleId",
+													"value": "{{budgetRuleId}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:19:07 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "3"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "ANWG7PZ1MTH68RCXNZ3M"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "7c1bd3b8-4c25-4596-a752-7729fbded41c"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "ANWG7PZ1MTH68RCXNZ3M"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:19:07 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "3"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq22yGmGIAMFXWg="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f4382b-f178d333423a74ae085c578e"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:19:06 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{}"
+								}
+							]
+						},
+						{
+							"name": "Campaigns associated with a rule",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"/*Save campaignId from first object to environment*/",
+											"var response = JSON.parse(responseBody);",
+											"if(response.totalResults === 0) {",
+											"        console.info(\"No campaigns were returned.\");",
+											"} else {",
+											"",
+											"    if(responseCode.code === 200) {",
+											"    var response = JSON.parse(responseBody);",
+											"    var campaignId = response.campaigns[0].campaignId",
+											"    postman.clearEnvironmentVariable(\"campaignId\");",
+											"    postman.setEnvironmentVariable(\"campaignId\", campaignId); ",
+											"        console.log(\"campaignId from first campaign object is \" + campaignId);",
+											"    } else {",
+											"        console.log(responseBody);",
+											"    }",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									}
+								],
+								"url": {
+									"raw": "{{api_url}}/sp/budgetRules/:budgetRuleId/campaigns?pageSize=30",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sp",
+										"budgetRules",
+										":budgetRuleId",
+										"campaigns"
+									],
+									"query": [
+										{
+											"key": "pageSize",
+											"value": "30"
+										},
+										{
+											"key": "nextToken",
+											"value": null,
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "budgetRuleId",
+											"value": "{{budgetRuleId}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/sp/budgetRules/:budgetRuleId/campaigns?pageSize=30",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sp",
+												"budgetRules",
+												":budgetRuleId",
+												"campaigns"
+											],
+											"query": [
+												{
+													"key": "pageSize",
+													"value": "30"
+												},
+												{
+													"key": "nextToken",
+													"value": null,
+													"disabled": true
+												}
+											],
+											"variable": [
+												{
+													"key": "budgetRuleId",
+													"value": "{{budgetRuleId}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Mon, 20 Feb 2023 17:03:30 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "146"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "T5MHPSDX7S14CPTA5G96"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "483da119-0f4c-4921-953a-b17a01165517"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "T5MHPSDX7S14CPTA5G96"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Mon, 20 Feb 2023 17:03:30 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "146"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "ApcrbFlhIAMFzxA="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f3a7e2-a50c0c143620610a8ce2593c"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Mon, 20 Feb 2023 17:03:30 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"associatedCampaigns\": [\n        {\n            \"campaignId\": \"102028944323821\",\n            \"campaignName\": \"Campaign - 2/20/2023 11:52:05\",\n            \"ruleStatus\": \"ON_HOLD\"\n        }\n    ],\n    \"nextToken\": null\n}"
+								}
+							]
+						},
+						{
+							"name": "Budget rule by ID",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									}
+								],
+								"url": {
+									"raw": "{{api_url}}/sp/budgetRules/:budgetRuleId",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sp",
+										"budgetRules",
+										":budgetRuleId"
+									],
+									"variable": [
+										{
+											"key": "budgetRuleId",
+											"value": "{{budgetRuleId}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/sp/budgetRules/:budgetRuleId",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sp",
+												"budgetRules",
+												":budgetRuleId"
+											],
+											"variable": [
+												{
+													"key": "budgetRuleId",
+													"value": "{{budgetRuleId}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Mon, 20 Feb 2023 16:59:39 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "617"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "0EDT072240KNMZ79AZEK"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "ece8866d-bad2-4614-b295-9a410c3f6b3d"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "0EDT072240KNMZ79AZEK"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Mon, 20 Feb 2023 16:59:39 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "617"
+										},
+										{
+											"key": "x-amzn-Remapped-Connection",
+											"value": "close"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "ApcHTFC-oAMFjww="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f3a6fb-924827d85a94557fa7b86ba9"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Mon, 20 Feb 2023 16:59:38 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"budgetRule\": {\n        \"createdDate\": 1676912194576,\n        \"lastUpdatedDate\": 1676912194576,\n        \"ruleDetails\": {\n            \"budgetIncreaseBy\": {\n                \"type\": \"PERCENT\",\n                \"value\": 25\n            },\n            \"duration\": {\n                \"dateRangeTypeRuleDuration\": {\n                    \"endDate\": \"20230228\",\n                    \"startDate\": \"20230220\"\n                },\n                \"eventTypeRuleDuration\": null\n            },\n            \"name\": \"Spring Budget Rule\",\n            \"performanceMeasureCondition\": {\n                \"comparisonOperator\": \"GREATER_THAN_OR_EQUAL_TO\",\n                \"metricName\": \"ROAS\",\n                \"threshold\": 2\n            },\n            \"recurrence\": {\n                \"daysOfWeek\": null,\n                \"intraDaySchedule\": null,\n                \"type\": \"DAILY\"\n            },\n            \"ruleType\": \"PERFORMANCE\"\n        },\n        \"ruleId\": \"f1eded08-af77-454a-b307-7783802657e2\",\n        \"ruleState\": \"ACTIVE\",\n        \"ruleStatus\": \"ACTIVE\",\n        \"ruleStatusDetails\": null\n    }\n}"
+								}
+							]
+						},
+						{
+							"name": "Rules associated with a campaign",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									},
+									{
+										"key": "",
+										"value": "",
+										"type": "default",
+										"disabled": true
+									}
+								],
+								"url": {
+									"raw": "{{api_url}}/sp/campaigns/:campaignId/budgetRules",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sp",
+										"campaigns",
+										":campaignId",
+										"budgetRules"
+									],
+									"query": [
+										{
+											"key": "nextToken",
+											"value": null,
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "campaignId",
+											"value": "{{campaignId}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/sp/campaigns/:campaignId/budgetRules",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sp",
+												"campaigns",
+												":campaignId",
+												"budgetRules"
+											],
+											"query": [
+												{
+													"key": "nextToken",
+													"value": null,
+													"disabled": true
+												}
+											],
+											"variable": [
+												{
+													"key": "campaignId",
+													"value": "{{campaignId}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Mon, 20 Feb 2023 17:00:14 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "1333"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "KF72AWK69CGTAKYBFXQR"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "61f10a9b-b2a8-403f-9d04-c117771e1b55"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "KF72AWK69CGTAKYBFXQR"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Mon, 20 Feb 2023 17:00:14 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "1333"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "ApcM0G5SoAMFQEA="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f3a71e-075db1a13cdd6780e6df1615"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Mon, 20 Feb 2023 17:00:13 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"associatedRules\": [\n        {\n            \"createdDate\": 1676912194576,\n            \"lastUpdatedDate\": 1676912194576,\n            \"ruleDetails\": {\n                \"budgetIncreaseBy\": {\n                    \"type\": \"PERCENT\",\n                    \"value\": 25\n                },\n                \"duration\": {\n                    \"dateRangeTypeRuleDuration\": {\n                        \"endDate\": \"20230228\",\n                        \"startDate\": \"20230220\"\n                    },\n                    \"eventTypeRuleDuration\": null\n                },\n                \"name\": \"Spring Budget Rule\",\n                \"performanceMeasureCondition\": {\n                    \"comparisonOperator\": \"GREATER_THAN_OR_EQUAL_TO\",\n                    \"metricName\": \"ROAS\",\n                    \"threshold\": 2\n                },\n                \"recurrence\": {\n                    \"daysOfWeek\": null,\n                    \"intraDaySchedule\": null,\n                    \"type\": \"DAILY\"\n                },\n                \"ruleType\": \"PERFORMANCE\"\n            },\n            \"ruleId\": \"f1eded08-af77-454a-b307-7783802657e2\",\n            \"ruleState\": \"ACTIVE\",\n            \"ruleStatus\": \"ON_HOLD\",\n            \"ruleStatusDetails\": {\n                \"reasonCode\": \"INELIGIBLE_PERFORMANCE_METRIC\",\n                \"status\": \"ON_HOLD\"\n            }\n        },\n        {\n            \"createdDate\": 1676912153402,\n            \"lastUpdatedDate\": 1676912153402,\n            \"ruleDetails\": {\n                \"budgetIncreaseBy\": {\n                    \"type\": \"PERCENT\",\n                    \"value\": 20\n                },\n                \"duration\": {\n                    \"dateRangeTypeRuleDuration\": null,\n                    \"eventTypeRuleDuration\": {\n                        \"endDate\": \"20230515\",\n                        \"eventId\": \"1b943597-d48e-5147-abd1-7ed20fcb693c\",\n                        \"eventName\": \"Mother's Day\",\n                        \"startDate\": \"20230511\"\n                    }\n                },\n                \"name\": \"Mother's Day Budget Rule\",\n                \"performanceMeasureCondition\": null,\n                \"recurrence\": {\n                    \"daysOfWeek\": null,\n                    \"intraDaySchedule\": null,\n                    \"type\": \"DAILY\"\n                },\n                \"ruleType\": \"SCHEDULE\"\n            },\n            \"ruleId\": \"c29298a0-0369-4146-8065-a73d33d51779\",\n            \"ruleState\": \"ACTIVE\",\n            \"ruleStatus\": \"PENDING_START\",\n            \"ruleStatusDetails\": {\n                \"reasonCode\": null,\n                \"status\": \"PENDING_START\"\n            }\n        }\n    ]\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "SD",
+					"item": [
+						{
+							"name": "Create budget rules",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"/* Save ruleId to environment */",
+											"if(responseCode.code === 207) {",
+											"var response = JSON.parse(responseBody);",
+											"var budgetRuleId = response.responses[0].ruleId",
+											"postman.clearEnvironmentVariable(\"budgetRuleId\");",
+											"postman.setEnvironmentVariable(\"budgetRuleId\", budgetRuleId); ",
+											"    console.log(\"ruleId is \" + budgetRuleId);",
+											"} else {",
+											"    console.log(responseBody);",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									},
+									{
+										"key": "",
+										"value": "",
+										"type": "default",
+										"disabled": true
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"budgetRulesDetails\": [\n    {\n      \"name\": \"ACOS < 20%\",\n      \"ruleType\": \"PERFORMANCE\",\n      \"duration\": {\n        \"dateRangeTypeRuleDuration\": {\n          \"startDate\": \"20230301\",\n          \"endDate\": \"20230430\"\n        }\n      },\n      \"recurrence\": {\n        \"type\": \"DAILY\"\n      },\n      \"budgetIncreaseBy\": {\n        \"type\": \"PERCENT\",\n        \"value\": 20\n      },\n      \"performanceMeasureCondition\": {\n        \"metricName\": \"ACOS\",\n        \"threshold\": 20,\n        \"comparisonOperator\": \"LESS_THAN_OR_EQUAL_TO\"\n      }\n    }\n  ]\n}"
+								},
+								"url": {
+									"raw": "{{api_url}}/sd/budgetRules",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sd",
+										"budgetRules"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Scheduled, weekly rule",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"budgetRulesDetails\": [\n    {\n      \"name\": \"Spring 35%\",\n      \"ruleType\": \"SCHEDULE\",\n      \"duration\": {\n        \"dateRangeTypeRuleDuration\": {\n          \"startDate\": \"20230301\",\n          \"endDate\": \"20230430\"\n        }\n      },\n      \"recurrence\": {\n        \"type\": \"WEEKLY\",\n        \"daysOfWeek\": [\n          \"MONDAY\",\"WEDNESDAY\"\n        ]\n      },\n      \"budgetIncreaseBy\": {\n        \"type\": \"PERCENT\",\n        \"value\": 35\n      }\n    }\n  ]\n}"
+										},
+										"url": {
+											"raw": "{{api_url}}/sd/budgetRules",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sd",
+												"budgetRules"
+											]
+										}
+									},
+									"status": "Multi-Status (WebDAV) (RFC 4918)",
+									"code": 207,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:43:42 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "7M37X86D20F969C1DEDQ"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "2530cea3-a169-4ca8-add0-af90c9a4574e"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "7M37X86D20F969C1DEDQ"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:43:42 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "x-amzn-Remapped-Connection",
+											"value": "close"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq6dUEj8oAMFlOw="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f43dee-b8efc6b8e020fb2b1d635c8b"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:43:41 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"responses\": [\n        {\n            \"associatedCampaignIds\": null,\n            \"code\": \"Ok\",\n            \"details\": \"Budget rule created\",\n            \"ruleId\": \"3b12acec-cba0-45b8-bb10-59a44dc52896\"\n        }\n    ]\n}"
+								},
+								{
+									"name": "Performance-based rule",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"budgetRulesDetails\": [\n    {\n      \"name\": \"ACOS < 20%\",\n      \"ruleType\": \"PERFORMANCE\",\n      \"duration\": {\n        \"dateRangeTypeRuleDuration\": {\n          \"startDate\": \"20230301\",\n          \"endDate\": \"20230430\"\n        }\n      },\n      \"recurrence\": {\n        \"type\": \"DAILY\"\n      },\n      \"budgetIncreaseBy\": {\n        \"type\": \"PERCENT\",\n        \"value\": 20\n      },\n      \"performanceMeasureCondition\": {\n        \"metricName\": \"ACOS\",\n        \"threshold\": 20,\n        \"comparisonOperator\": \"LESS_THAN_OR_EQUAL_TO\"\n      }\n    }\n  ]\n}"
+										},
+										"url": {
+											"raw": "{{api_url}}/sd/budgetRules",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sd",
+												"budgetRules"
+											]
+										}
+									},
+									"status": "Multi-Status (WebDAV) (RFC 4918)",
+									"code": 207,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:46:11 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "E3T9BSDHWX5GV1G2AQ8Z"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "a1b2209a-342e-437a-886a-642ddd050582"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "E3T9BSDHWX5GV1G2AQ8Z"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:46:11 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "x-amzn-Remapped-Connection",
+											"value": "close"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq60iEcaIAMFXtw="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f43e83-61138e6738d959eda0e09434"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:46:11 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"responses\": [\n        {\n            \"associatedCampaignIds\": null,\n            \"code\": \"Ok\",\n            \"details\": \"Budget rule created\",\n            \"ruleId\": \"89f07de4-e24c-4aa0-bffd-7ae916b65b50\"\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "Associate budget rules to campaign",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									},
+									{
+										"key": "",
+										"value": "",
+										"type": "default",
+										"disabled": true
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"budgetRuleIds\": [\n    \"{{budgetRuleId}}\"\n  ]\n}"
+								},
+								"url": {
+									"raw": "{{api_url}}/sd/campaigns/:campaignId/budgetRules",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sd",
+										"campaigns",
+										":campaignId",
+										"budgetRules"
+									],
+									"variable": [
+										{
+											"key": "campaignId",
+											"value": "{{campaignId}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"budgetRuleIds\": [\n    \"{{budgetRuleId}}\"\n  ]\n}"
+										},
+										"url": {
+											"raw": "{{api_url}}/sd/campaigns/:campaignId/budgetRules",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sd",
+												"campaigns",
+												":campaignId",
+												"budgetRules"
+											],
+											"variable": [
+												{
+													"key": "campaignId",
+													"value": "{{campaignId}}"
+												}
+											]
+										}
+									},
+									"status": "Multi-Status (WebDAV) (RFC 4918)",
+									"code": 207,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:46:47 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "113"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "12T3ED9DWDF19E155D0G"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "765df155-33aa-45b4-a5cd-6f792dcad5b8"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "12T3ED9DWDF19E155D0G"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:46:47 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "113"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq66EHJRIAMF5NA="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f43ea6-a48df5066713a8f0a3ed9c88"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:46:46 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"responses\": [\n        {\n            \"code\": \"Ok\",\n            \"details\": \"Budget rule associated\",\n            \"ruleId\": \"89f07de4-e24c-4aa0-bffd-7ae916b65b50\"\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "All budget rules",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"/*Save budgetRuleId from first object to environment*/",
+											"",
+											"if (responseCode.code === 200) {",
+											"    var response = JSON.parse(responseBody);",
+											"    if(!response.budgetRulesForAdvertiserResponse[0]) {",
+											"        console.info(\"No rules were returned.\");",
+											"    } else {",
+											"        var budgetRuleId = response.budgetRulesForAdvertiserResponse[0].ruleId",
+											"        postman.clearEnvironmentVariable(\"budgetRuleId\");",
+											"        postman.setEnvironmentVariable(\"budgetRuleId\", budgetRuleId); ",
+											"        console.log(\"budgetRuleId from first rule object is \" + budgetRuleId);",
+											"    } ",
+											"} else {",
+											"    console.log(responseCode, responseBody);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									},
+									{
+										"key": "",
+										"value": "",
+										"type": "default",
+										"disabled": true
+									}
+								],
+								"url": {
+									"raw": "{{api_url}}/sd/budgetRules?pageSize=30",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sd",
+										"budgetRules"
+									],
+									"query": [
+										{
+											"key": "nextToken",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "pageSize",
+											"value": "30"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/sd/budgetRules?pageSize=30",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sd",
+												"budgetRules"
+											],
+											"query": [
+												{
+													"key": "nextToken",
+													"value": null,
+													"disabled": true
+												},
+												{
+													"key": "pageSize",
+													"value": "30"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:47:30 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "1191"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "ER4M3S32R1EWY1Y73PN4"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "da6d1635-fed6-4414-a85e-e7d66769dd22"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "ER4M3S32R1EWY1Y73PN4"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:47:30 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "1191"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq7A8HXxoAMF2QQ="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f43ed2-37e98abcfda32ef66540f7fa"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:47:30 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"budgetRulesForAdvertiserResponse\": [\n        {\n            \"createdDate\": 1676951022655,\n            \"lastUpdatedDate\": 1676951022655,\n            \"ruleDetails\": {\n                \"budgetIncreaseBy\": {\n                    \"type\": \"PERCENT\",\n                    \"value\": 35\n                },\n                \"duration\": {\n                    \"dateRangeTypeRuleDuration\": {\n                        \"endDate\": \"20230430\",\n                        \"startDate\": \"20230301\"\n                    },\n                    \"eventTypeRuleDuration\": null\n                },\n                \"name\": \"Spring 35%\",\n                \"performanceMeasureCondition\": null,\n                \"recurrence\": {\n                    \"daysOfWeek\": [\n                        \"MONDAY\",\n                        \"WEDNESDAY\"\n                    ],\n                    \"intraDaySchedule\": null,\n                    \"type\": \"WEEKLY\"\n                },\n                \"ruleType\": \"SCHEDULE\"\n            },\n            \"ruleId\": \"3b12acec-cba0-45b8-bb10-59a44dc52896\",\n            \"ruleState\": \"ACTIVE\",\n            \"ruleStatus\": \"PENDING_START\",\n            \"ruleStatusDetails\": null\n        },\n        {\n            \"createdDate\": 1676951171268,\n            \"lastUpdatedDate\": 1676951171268,\n            \"ruleDetails\": {\n                \"budgetIncreaseBy\": {\n                    \"type\": \"PERCENT\",\n                    \"value\": 20\n                },\n                \"duration\": {\n                    \"dateRangeTypeRuleDuration\": {\n                        \"endDate\": \"20230430\",\n                        \"startDate\": \"20230301\"\n                    },\n                    \"eventTypeRuleDuration\": null\n                },\n                \"name\": \"ACOS < 20%\",\n                \"performanceMeasureCondition\": {\n                    \"comparisonOperator\": \"LESS_THAN_OR_EQUAL_TO\",\n                    \"metricName\": \"ACOS\",\n                    \"threshold\": 20\n                },\n                \"recurrence\": {\n                    \"daysOfWeek\": null,\n                    \"intraDaySchedule\": null,\n                    \"type\": \"DAILY\"\n                },\n                \"ruleType\": \"PERFORMANCE\"\n            },\n            \"ruleId\": \"89f07de4-e24c-4aa0-bffd-7ae916b65b50\",\n            \"ruleState\": \"ACTIVE\",\n            \"ruleStatus\": \"PENDING_START\",\n            \"ruleStatusDetails\": null\n        }\n    ],\n    \"nextToken\": null\n}"
+								}
+							]
+						},
+						{
+							"name": "Update budget rules",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									},
+									{
+										"key": "",
+										"value": "",
+										"type": "default",
+										"disabled": true
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"budgetRulesDetails\": [\n    {\n      \"ruleId\": \"{{budgetRuleId}}\",\n      \"ruleState\": \"PAUSED\"\n    }\n  ]\n}"
+								},
+								"url": {
+									"raw": "{{api_url}}/sd/budgetRules",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sd",
+										"budgetRules"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Update name, end date, increase value",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"budgetRulesDetails\": [\n    {\n      \"lastUpdatedDate\": null,\n      \"ruleDetails\": {\n        \"ruleType\": \"PERFORMANCE\",\n        \"name\": \"Spring Budget Rule - Updated\",\n        \"duration\": {\n          \"dateRangeTypeRuleDuration\": {\n            \"startDate\": \"20230220\",\n            \"endDate\": \"20230308\"\n          }\n        },\n        \"recurrence\": {\n          \"type\": \"DAILY\"\n        },\n        \"budgetIncreaseBy\": {\n          \"type\": \"PERCENT\",\n          \"value\": 75\n        },\n        \"performanceMeasureCondition\": {\n          \"metricName\": \"ROAS\",\n          \"comparisonOperator\": \"GREATER_THAN_OR_EQUAL_TO\",\n          \"threshold\": 2.0\n        }\n      },\n      \"ruleId\": \"{{budgetRuleId}}\",\n      \"ruleState\": \"ACTIVE\",\n      \"ruleStatus\": \"ACTIVE\",\n      \"ruleStatusDetails\": null\n    }\n  ]\n}"
+										},
+										"url": {
+											"raw": "{{api_url}}/sd/budgetRules",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sd",
+												"budgetRules"
+											]
+										}
+									},
+									"status": "Multi-Status (WebDAV) (RFC 4918)",
+									"code": 207,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:47:51 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "A6NBGVWD21W8ZRXSNN6B"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "935641ad-ae7b-469f-96c4-dc80b8cbf3b6"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "A6NBGVWD21W8ZRXSNN6B"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:47:51 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq7ERG0IoAMFTKg="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f43ee7-86bd2bce65646bc03a626a2c"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:47:51 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"responses\": [\n        {\n            \"associatedCampaignIds\": null,\n            \"code\": \"Ok\",\n            \"details\": \"Budget rule updated\",\n            \"ruleId\": \"3b12acec-cba0-45b8-bb10-59a44dc52896\"\n        }\n    ]\n}"
+								},
+								{
+									"name": "Update rule state",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"budgetRulesDetails\": [\n    {\n      \"ruleId\": \"{{budgetRuleId}}\",\n      \"ruleState\": \"PAUSED\"\n    }\n  ]\n}"
+										},
+										"url": {
+											"raw": "{{api_url}}/sd/budgetRules",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sd",
+												"budgetRules"
+											]
+										}
+									},
+									"status": "Multi-Status (WebDAV) (RFC 4918)",
+									"code": 207,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:48:47 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "SXHBP2GVV9TDGSQQ6XEN"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "591d8261-b909-4e1c-8865-f694e23e25bd"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "SXHBP2GVV9TDGSQQ6XEN"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:48:47 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq7M6EHsIAMFpZw="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f43f1f-99833e08d38b0f4991b8e3f8"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:48:46 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"responses\": [\n        {\n            \"associatedCampaignIds\": null,\n            \"code\": \"Ok\",\n            \"details\": \"Budget rule updated\",\n            \"ruleId\": \"3b12acec-cba0-45b8-bb10-59a44dc52896\"\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "Disassociate budget rule from campaign",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									}
+								],
+								"url": {
+									"raw": "{{api_url}}/sd/campaigns/:campaignId/budgetRules/:budgetRuleId",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sd",
+										"campaigns",
+										":campaignId",
+										"budgetRules",
+										":budgetRuleId"
+									],
+									"variable": [
+										{
+											"key": "campaignId",
+											"value": "{{campaignId}}"
+										},
+										{
+											"key": "budgetRuleId",
+											"value": "{{budgetRuleId}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/sd/campaigns/:campaignId/budgetRules/:budgetRuleId",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sd",
+												"campaigns",
+												":campaignId",
+												"budgetRules",
+												":budgetRuleId"
+											],
+											"variable": [
+												{
+													"key": "campaignId",
+													"value": "{{campaignId}}"
+												},
+												{
+													"key": "budgetRuleId",
+													"value": "{{budgetRuleId}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:49:31 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "3"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "C2RZXC6JTY2VKGPFG3BT"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "6fbf17ed-5de1-4911-8d1e-adfc1da5f4f0"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "C2RZXC6JTY2VKGPFG3BT"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:49:31 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "3"
+										},
+										{
+											"key": "x-amzn-Remapped-Connection",
+											"value": "close"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq7TsHEAIAMFd5A="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f43f4b-c96b5b89c6cba97a224fd70b"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:49:30 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{}"
+								}
+							]
+						},
+						{
+							"name": "Campaigns associated with a rule",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"/*Save campaignId from first object to environment*/",
+											"var response = JSON.parse(responseBody);",
+											"if(response.totalResults === 0) {",
+											"        console.info(\"No campaigns were returned.\");",
+											"} else {",
+											"",
+											"    if(responseCode.code === 200) {",
+											"    var response = JSON.parse(responseBody);",
+											"    var campaignId = response.campaigns[0].campaignId",
+											"    postman.clearEnvironmentVariable(\"campaignId\");",
+											"    postman.setEnvironmentVariable(\"campaignId\", campaignId); ",
+											"        console.log(\"campaignId from first campaign object is \" + campaignId);",
+											"    } else {",
+											"        console.log(responseBody);",
+											"    }",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									}
+								],
+								"url": {
+									"raw": "{{api_url}}/sd/budgetRules/:budgetRuleId/campaigns?pageSize=30",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sd",
+										"budgetRules",
+										":budgetRuleId",
+										"campaigns"
+									],
+									"query": [
+										{
+											"key": "pageSize",
+											"value": "30"
+										},
+										{
+											"key": "nextToken",
+											"value": null,
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "budgetRuleId",
+											"value": "{{budgetRuleId}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/sd/budgetRules/:budgetRuleId/campaigns?pageSize=30",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sd",
+												"budgetRules",
+												":budgetRuleId",
+												"campaigns"
+											],
+											"query": [
+												{
+													"key": "pageSize",
+													"value": "30"
+												},
+												{
+													"key": "nextToken",
+													"value": null,
+													"disabled": true
+												}
+											],
+											"variable": [
+												{
+													"key": "budgetRuleId",
+													"value": "{{budgetRuleId}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:50:35 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "145"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "TS1MZ58FM263CZF0TBVP"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "cb2c92c8-77f2-4cc1-9d8f-8739cfe2b23a"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "TS1MZ58FM263CZF0TBVP"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:50:35 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "145"
+										},
+										{
+											"key": "x-amzn-Remapped-Connection",
+											"value": "close"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq7d2GkZoAMFTcw="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f43f8b-a03efb5ff1c0a7696e413866"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:50:35 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"associatedCampaigns\": [\n        {\n            \"campaignId\": \"144765279800494\",\n            \"campaignName\": \"Campaign - 2/20/2023 22:44:56\",\n            \"ruleStatus\": \"PAUSED\"\n        }\n    ],\n    \"nextToken\": null\n}"
+								}
+							]
+						},
+						{
+							"name": "Budget rule by ID",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									}
+								],
+								"url": {
+									"raw": "{{api_url}}/sd/budgetRules/:budgetRuleId",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sd",
+										"budgetRules",
+										":budgetRuleId"
+									],
+									"variable": [
+										{
+											"key": "budgetRuleId",
+											"value": "{{budgetRuleId}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/sd/budgetRules/:budgetRuleId",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sd",
+												"budgetRules",
+												":budgetRuleId"
+											],
+											"variable": [
+												{
+													"key": "budgetRuleId",
+													"value": "{{budgetRuleId}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:50:15 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "618"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "W73PTBD723G8V10DVV2S"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "1065ef44-6ed5-44b9-92f3-5cabf41543b1"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "W73PTBD723G8V10DVV2S"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:50:15 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "618"
+										},
+										{
+											"key": "x-amzn-Remapped-Connection",
+											"value": "close"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq7asHu-IAMF07A="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f43f77-e8566d44f74ce72ed7fbc913"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:50:15 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"budgetRule\": {\n        \"createdDate\": 1676951022655,\n        \"lastUpdatedDate\": null,\n        \"ruleDetails\": {\n            \"budgetIncreaseBy\": {\n                \"type\": \"PERCENT\",\n                \"value\": 75\n            },\n            \"duration\": {\n                \"dateRangeTypeRuleDuration\": {\n                    \"endDate\": \"20230308\",\n                    \"startDate\": \"20230220\"\n                },\n                \"eventTypeRuleDuration\": null\n            },\n            \"name\": \"Spring Budget Rule - Updated\",\n            \"performanceMeasureCondition\": {\n                \"comparisonOperator\": \"GREATER_THAN_OR_EQUAL_TO\",\n                \"metricName\": \"ROAS\",\n                \"threshold\": 2\n            },\n            \"recurrence\": {\n                \"daysOfWeek\": null,\n                \"intraDaySchedule\": null,\n                \"type\": \"DAILY\"\n            },\n            \"ruleType\": \"PERFORMANCE\"\n        },\n        \"ruleId\": \"3b12acec-cba0-45b8-bb10-59a44dc52896\",\n        \"ruleState\": \"PAUSED\",\n        \"ruleStatus\": \"PAUSED\",\n        \"ruleStatusDetails\": null\n    }\n}"
+								}
+							]
+						},
+						{
+							"name": "Rules associated with a campaign",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									},
+									{
+										"key": "",
+										"value": "",
+										"type": "default",
+										"disabled": true
+									}
+								],
+								"url": {
+									"raw": "{{api_url}}/sd/campaigns/:campaignId/budgetRules",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sd",
+										"campaigns",
+										":campaignId",
+										"budgetRules"
+									],
+									"variable": [
+										{
+											"key": "campaignId",
+											"value": "{{campaignId}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/sd/campaigns/:campaignId/budgetRules",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sd",
+												"campaigns",
+												":campaignId",
+												"budgetRules"
+											],
+											"variable": [
+												{
+													"key": "campaignId",
+													"value": "{{campaignId}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:51:13 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "1297"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "6KJ3TTHS70FQAWZBF4BV"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "c493f119-967b-4b08-ba8c-f18320d2e315"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "6KJ3TTHS70FQAWZBF4BV"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:51:13 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "1297"
+										},
+										{
+											"key": "x-amzn-Remapped-Connection",
+											"value": "close"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq7jtGG7IAMFx6Q="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f43fb1-0026c341e31684e72aa44b0f"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:51:12 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"associatedRules\": [\n        {\n            \"createdDate\": 1676951022655,\n            \"lastUpdatedDate\": null,\n            \"ruleDetails\": {\n                \"budgetIncreaseBy\": {\n                    \"type\": \"PERCENT\",\n                    \"value\": 75\n                },\n                \"duration\": {\n                    \"dateRangeTypeRuleDuration\": {\n                        \"endDate\": \"20230308\",\n                        \"startDate\": \"20230220\"\n                    },\n                    \"eventTypeRuleDuration\": null\n                },\n                \"name\": \"Spring Budget Rule - Updated\",\n                \"performanceMeasureCondition\": {\n                    \"comparisonOperator\": \"GREATER_THAN_OR_EQUAL_TO\",\n                    \"metricName\": \"ROAS\",\n                    \"threshold\": 2\n                },\n                \"recurrence\": {\n                    \"daysOfWeek\": null,\n                    \"intraDaySchedule\": null,\n                    \"type\": \"DAILY\"\n                },\n                \"ruleType\": \"PERFORMANCE\"\n            },\n            \"ruleId\": \"3b12acec-cba0-45b8-bb10-59a44dc52896\",\n            \"ruleState\": \"PAUSED\",\n            \"ruleStatus\": \"PAUSED\",\n            \"ruleStatusDetails\": {\n                \"reasonCode\": null,\n                \"status\": \"PAUSED\"\n            }\n        },\n        {\n            \"createdDate\": 1676951171268,\n            \"lastUpdatedDate\": 1676951171268,\n            \"ruleDetails\": {\n                \"budgetIncreaseBy\": {\n                    \"type\": \"PERCENT\",\n                    \"value\": 20\n                },\n                \"duration\": {\n                    \"dateRangeTypeRuleDuration\": {\n                        \"endDate\": \"20230430\",\n                        \"startDate\": \"20230301\"\n                    },\n                    \"eventTypeRuleDuration\": null\n                },\n                \"name\": \"ACOS < 20%\",\n                \"performanceMeasureCondition\": {\n                    \"comparisonOperator\": \"LESS_THAN_OR_EQUAL_TO\",\n                    \"metricName\": \"ACOS\",\n                    \"threshold\": 20\n                },\n                \"recurrence\": {\n                    \"daysOfWeek\": null,\n                    \"intraDaySchedule\": null,\n                    \"type\": \"DAILY\"\n                },\n                \"ruleType\": \"PERFORMANCE\"\n            },\n            \"ruleId\": \"89f07de4-e24c-4aa0-bffd-7ae916b65b50\",\n            \"ruleState\": \"ACTIVE\",\n            \"ruleStatus\": \"PENDING_START\",\n            \"ruleStatusDetails\": {\n                \"reasonCode\": null,\n                \"status\": \"PENDING_START\"\n            }\n        }\n    ]\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "SB",
+					"item": [
+						{
+							"name": "Create budget rules",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"/* Save ruleId to environment */",
+											"if(responseCode.code === 207) {",
+											"var response = JSON.parse(responseBody);",
+											"var budgetRuleId = response.responses[0].ruleId",
+											"postman.clearEnvironmentVariable(\"budgetRuleId\");",
+											"postman.setEnvironmentVariable(\"budgetRuleId\", budgetRuleId); ",
+											"    console.log(\"ruleId is \" + budgetRuleId);",
+											"} else {",
+											"    console.log(responseBody);",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									},
+									{
+										"key": "",
+										"value": "",
+										"type": "default",
+										"disabled": true
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"budgetRulesDetails\": [\n    {\n      \"name\": \"Easter 25%\",\n      \"ruleType\": \"SCHEDULE\",\n      \"duration\": {\n        \"eventTypeRuleDuration\": {\n          \"eventId\": \"{{eventId}}\"\n        }\n      },\n      \"recurrence\": {\n        \"type\": \"DAILY\"\n      },\n      \"budgetIncreaseBy\": {\n        \"type\": \"PERCENT\",\n        \"value\": 25\n      }\n    }\n  ]\n}"
+								},
+								"url": {
+									"raw": "{{api_url}}/sb/budgetRules",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sb",
+										"budgetRules"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Scheduled, weekly rule",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"budgetRulesDetails\": [\n    {\n      \"name\": \"Spring 35%\",\n      \"ruleType\": \"SCHEDULE\",\n      \"duration\": {\n        \"dateRangeTypeRuleDuration\": {\n          \"startDate\": \"20230301\",\n          \"endDate\": \"20230430\"\n        }\n      },\n      \"recurrence\": {\n        \"type\": \"WEEKLY\",\n        \"daysOfWeek\": [\n          \"MONDAY\",\"WEDNESDAY\"\n        ]\n      },\n      \"budgetIncreaseBy\": {\n        \"type\": \"PERCENT\",\n        \"value\": 35\n      }\n    }\n  ]\n}"
+										},
+										"url": {
+											"raw": "{{api_url}}/sb/budgetRules",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sb",
+												"budgetRules"
+											]
+										}
+									},
+									"status": "Multi-Status (WebDAV) (RFC 4918)",
+									"code": 207,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:22:01 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "GRW6AP7WX24X1G4J0VCK"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "f999385d-becd-4f8e-8b7c-a709d43799b1"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "GRW6AP7WX24X1G4J0VCK"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:22:01 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "x-amzn-Remapped-Connection",
+											"value": "close"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq3SDHRcoAMF4sQ="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f438d9-9f750bfb62be9426997acbff"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:22:00 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"responses\": [\n        {\n            \"associatedCampaignIds\": null,\n            \"code\": \"Ok\",\n            \"details\": \"Budget rule created\",\n            \"ruleId\": \"7788e003-ff0b-4005-bcfb-b68936103a9d\"\n        }\n    ]\n}"
+								},
+								{
+									"name": "Performance-based rule",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"budgetRulesDetails\": [\n    {\n      \"name\": \"ACOS < 20%\",\n      \"ruleType\": \"PERFORMANCE\",\n      \"duration\": {\n        \"dateRangeTypeRuleDuration\": {\n          \"startDate\": \"20230301\",\n          \"endDate\": \"20230430\"\n        }\n      },\n      \"recurrence\": {\n        \"type\": \"DAILY\"\n      },\n      \"budgetIncreaseBy\": {\n        \"type\": \"PERCENT\",\n        \"value\": 20\n      },\n      \"performanceMeasureCondition\": {\n        \"metricName\": \"ROAS\",\n        \"threshold\": 20,\n        \"comparisonOperator\": \"LESS_THAN_OR_EQUAL_TO\"\n      }\n    }\n  ]\n}"
+										},
+										"url": {
+											"raw": "{{api_url}}/sb/budgetRules",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sb",
+												"budgetRules"
+											]
+										}
+									},
+									"status": "Multi-Status (WebDAV) (RFC 4918)",
+									"code": 207,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:23:51 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "M9WF55D6MJ3JE89ZBY35"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "862016f5-fbab-4063-895d-af1db3fc995b"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "M9WF55D6MJ3JE89ZBY35"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:23:51 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq3jQFURIAMFjjw="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f43947-ccb94a1f7407520189b6b535"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:23:51 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"responses\": [\n        {\n            \"associatedCampaignIds\": null,\n            \"code\": \"Ok\",\n            \"details\": \"Budget rule created\",\n            \"ruleId\": \"19b62c40-0f4a-4995-adfb-a921808e7788\"\n        }\n    ]\n}"
+								},
+								{
+									"name": "Event-based, scheduled, daily rule",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"budgetRulesDetails\": [\n    {\n      \"name\": \"Easter 25%\",\n      \"ruleType\": \"SCHEDULE\",\n      \"duration\": {\n        \"eventTypeRuleDuration\": {\n          \"eventId\": \"899f0ac0-987c-00b8-146a-bf380f43b671\"\n        }\n      },\n      \"recurrence\": {\n        \"type\": \"DAILY\"\n      },\n      \"budgetIncreaseBy\": {\n        \"type\": \"PERCENT\",\n        \"value\": 25\n      }\n    }\n  ]\n}"
+										},
+										"url": {
+											"raw": "{{api_url}}/sb/budgetRules",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sb",
+												"budgetRules"
+											]
+										}
+									},
+									"status": "Multi-Status (WebDAV) (RFC 4918)",
+									"code": 207,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:39:35 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "CHN76G9CMSBK2HD7P581"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "2d3b43b6-4ebd-4436-8b18-5cfca7278cda"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "CHN76G9CMSBK2HD7P581"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:39:35 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq52uGTFIAMFtLA="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f43cf7-499176fb960fe3de498d48b3"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:39:34 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"responses\": [\n        {\n            \"associatedCampaignIds\": null,\n            \"code\": \"Ok\",\n            \"details\": \"Budget rule created\",\n            \"ruleId\": \"52323b15-3202-46f4-a04b-e90f8940508f\"\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "Associate budget rules to campaign",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									},
+									{
+										"key": "",
+										"value": "",
+										"type": "default",
+										"disabled": true
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"budgetRuleIds\": [\n    \"{{budgetRuleId}}\"\n  ]\n}"
+								},
+								"url": {
+									"raw": "{{api_url}}/sb/campaigns/:campaignId/budgetRules",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sb",
+										"campaigns",
+										":campaignId",
+										"budgetRules"
+									],
+									"query": [
+										{
+											"key": "nextToken",
+											"value": null,
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "campaignId",
+											"value": "{{campaignId}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"budgetRuleIds\": [\n    \"7788e003-ff0b-4005-bcfb-b68936103a9d\"\n  ]\n}"
+										},
+										"url": {
+											"raw": "{{api_url}}/sb/campaigns/:campaignId/budgetRules",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sb",
+												"campaigns",
+												":campaignId",
+												"budgetRules"
+											],
+											"query": [
+												{
+													"key": "nextToken",
+													"value": null,
+													"disabled": true
+												}
+											],
+											"variable": [
+												{
+													"key": "campaignId",
+													"value": "{{campaignId}}"
+												}
+											]
+										}
+									},
+									"status": "Multi-Status (WebDAV) (RFC 4918)",
+									"code": 207,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:33:04 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "113"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "X2HQN3R55624FY7FKKJQ"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "c4be822a-d373-4873-ae7d-ca1154ee3afd"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "X2HQN3R55624FY7FKKJQ"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:33:04 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "113"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq45kEQBIAMFfHw="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f43b70-21f3ef406a2e4ae14a1b8b82"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:33:04 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"responses\": [\n        {\n            \"code\": \"Ok\",\n            \"details\": \"Budget rule associated\",\n            \"ruleId\": \"7788e003-ff0b-4005-bcfb-b68936103a9d\"\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "Get recommended events",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											"/*Save eventId from first object to environment*/",
+											"",
+											"if (responseCode.code === 200) {",
+											"    var response = JSON.parse(responseBody);",
+											"    if(!response.recommendedBudgetRuleEvents[0]) {",
+											"        console.info(\"No events were returned.\");",
+											"    } else {",
+											"        var eventId = response.recommendedBudgetRuleEvents[0].eventId",
+											"        postman.clearEnvironmentVariable(\"eventId\");",
+											"        postman.setEnvironmentVariable(\"eventId\", eventId); ",
+											"        console.log(\"eventId from first event object is \" + eventId);",
+											"    } ",
+											"} else {",
+											"    console.log(responseCode, responseBody);",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/vnd.sbbudgetrulesrecommendation.v3+json",
+										"type": "default"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"campaignId\":\"{{campaignId}}\"\n}"
+								},
+								"url": {
+									"raw": "{{api_url}}/sb/campaigns/budgetRules/recommendations",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sb",
+										"campaigns",
+										"budgetRules",
+										"recommendations"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/vnd.sbbudgetrulesrecommendation.v3+json",
+												"type": "default"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"campaignId\":\"{{campaignId}}\"\n}"
+										},
+										"url": {
+											"raw": "{{api_url}}/sb/campaigns/budgetRules/recommendations",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sb",
+												"campaigns",
+												"budgetRules",
+												"recommendations"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:30:09 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/vnd.sbbudgetrulesrecommendation.v3+json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "1777"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "5HF1MYZQ4K3N1JFV3E34"
+										},
+										{
+											"key": "x-amz-request-id",
+											"value": "5HF1MYZQ4K3N1JFV3E34"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"recommendedBudgetRuleEvents\": [\n        {\n            \"endDate\": \"20230409\",\n            \"eventId\": \"899f0ac0-987c-00b8-146a-bf380f43b671\",\n            \"eventName\": \"Easter\",\n            \"startDate\": \"20230406\",\n            \"suggestedBudgetIncreasePercent\": null\n        },\n        {\n            \"endDate\": \"20230514\",\n            \"eventId\": \"aceadb70-d48d-36b2-504c-bedfe6a064e6\",\n            \"eventName\": \"Mother's day\",\n            \"startDate\": \"20230511\",\n            \"suggestedBudgetIncreasePercent\": 43\n        },\n        {\n            \"endDate\": \"20230529\",\n            \"eventId\": \"efd3f243-7a10-1177-7857-7bf52fa0bb23\",\n            \"eventName\": \"Memorial Day\",\n            \"startDate\": \"20230526\",\n            \"suggestedBudgetIncreasePercent\": null\n        },\n        {\n            \"endDate\": \"20230618\",\n            \"eventId\": \"3ce6b731-7b87-c728-ee52-aae04ab3620b\",\n            \"eventName\": \"Father's Day\",\n            \"startDate\": \"20230615\",\n            \"suggestedBudgetIncreasePercent\": null\n        },\n        {\n            \"endDate\": \"20230704\",\n            \"eventId\": \"58879a0b-82a6-412b-0a75-96ffea7ec847\",\n            \"eventName\": \"Independence Day\",\n            \"startDate\": \"20230701\",\n            \"suggestedBudgetIncreasePercent\": null\n        },\n        {\n            \"endDate\": \"20230904\",\n            \"eventId\": \"0bdd5eed-0eba-1a8d-2cdf-d77599d63f39\",\n            \"eventName\": \"Labor Day\",\n            \"startDate\": \"20230901\",\n            \"suggestedBudgetIncreasePercent\": 32\n        },\n        {\n            \"endDate\": \"20231031\",\n            \"eventId\": \"dc891b6d-84ff-339c-fd42-f89f63f47e7f\",\n            \"eventName\": \"Halloween\",\n            \"startDate\": \"20231028\",\n            \"suggestedBudgetIncreasePercent\": 25\n        },\n        {\n            \"endDate\": \"20231124\",\n            \"eventId\": \"4a4cb57f-9ea8-53e3-10c3-ad1de4966d05\",\n            \"eventName\": \"Black Friday\",\n            \"startDate\": \"20231121\",\n            \"suggestedBudgetIncreasePercent\": null\n        },\n        {\n            \"endDate\": \"20231127\",\n            \"eventId\": \"5ff2257a-d12f-dc30-43ee-0df7e1b63290\",\n            \"eventName\": \"Cyber Monday\",\n            \"startDate\": \"20231124\",\n            \"suggestedBudgetIncreasePercent\": null\n        },\n        {\n            \"endDate\": \"20231225\",\n            \"eventId\": \"781c59b1-557e-10bf-6b79-10f4adab5b37\",\n            \"eventName\": \"Christmas\",\n            \"startDate\": \"20231222\",\n            \"suggestedBudgetIncreasePercent\": null\n        },\n        {\n            \"endDate\": \"20231231\",\n            \"eventId\": \"da5293f7-f70d-664b-c87a-13f1b7cfd663\",\n            \"eventName\": \"New Years Eve\",\n            \"startDate\": \"20231228\",\n            \"suggestedBudgetIncreasePercent\": null\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "All budget rules",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"/*Save budgetRuleId from first object to environment*/",
+											"",
+											"if (responseCode.code === 200) {",
+											"    var response = JSON.parse(responseBody);",
+											"    if(!response.budgetRulesForAdvertiserResponse[0]) {",
+											"        console.info(\"No rules were returned.\");",
+											"    } else {",
+											"        var budgetRuleId = response.budgetRulesForAdvertiserResponse[0].ruleId",
+											"        postman.clearEnvironmentVariable(\"budgetRuleId\");",
+											"        postman.setEnvironmentVariable(\"budgetRuleId\", budgetRuleId); ",
+											"        console.log(\"budgetRuleId from first rule object is \" + budgetRuleId);",
+											"    } ",
+											"} else {",
+											"    console.log(responseCode, responseBody);",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									},
+									{
+										"key": "",
+										"value": "",
+										"type": "default",
+										"disabled": true
+									}
+								],
+								"url": {
+									"raw": "{{api_url}}/sb/budgetRules?pageSize=30",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sb",
+										"budgetRules"
+									],
+									"query": [
+										{
+											"key": "nextToken",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "pageSize",
+											"value": "30"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/sb/budgetRules?pageSize=30",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sb",
+												"budgetRules"
+											],
+											"query": [
+												{
+													"key": "nextToken",
+													"value": null,
+													"disabled": true
+												},
+												{
+													"key": "pageSize",
+													"value": "30"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:33:39 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "1191"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "JYY4C1JRK2GJ7R69KA9N"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "9bdd3093-e114-4dba-8fd5-f554472262f2"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "JYY4C1JRK2GJ7R69KA9N"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:33:39 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "1191"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq4_FEkUoAMF6tg="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f43b93-f4eaa80bb3f50fbc7ab442cf"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:33:39 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"budgetRulesForAdvertiserResponse\": [\n        {\n            \"createdDate\": 1676949831857,\n            \"lastUpdatedDate\": 1676949831857,\n            \"ruleDetails\": {\n                \"budgetIncreaseBy\": {\n                    \"type\": \"PERCENT\",\n                    \"value\": 20\n                },\n                \"duration\": {\n                    \"dateRangeTypeRuleDuration\": {\n                        \"endDate\": \"20230430\",\n                        \"startDate\": \"20230301\"\n                    },\n                    \"eventTypeRuleDuration\": null\n                },\n                \"name\": \"ACOS < 20%\",\n                \"performanceMeasureCondition\": {\n                    \"comparisonOperator\": \"LESS_THAN_OR_EQUAL_TO\",\n                    \"metricName\": \"ROAS\",\n                    \"threshold\": 20\n                },\n                \"recurrence\": {\n                    \"daysOfWeek\": null,\n                    \"intraDaySchedule\": null,\n                    \"type\": \"DAILY\"\n                },\n                \"ruleType\": \"PERFORMANCE\"\n            },\n            \"ruleId\": \"19b62c40-0f4a-4995-adfb-a921808e7788\",\n            \"ruleState\": \"ACTIVE\",\n            \"ruleStatus\": \"PENDING_START\",\n            \"ruleStatusDetails\": null\n        },\n        {\n            \"createdDate\": 1676949721783,\n            \"lastUpdatedDate\": 1676949721783,\n            \"ruleDetails\": {\n                \"budgetIncreaseBy\": {\n                    \"type\": \"PERCENT\",\n                    \"value\": 35\n                },\n                \"duration\": {\n                    \"dateRangeTypeRuleDuration\": {\n                        \"endDate\": \"20230430\",\n                        \"startDate\": \"20230301\"\n                    },\n                    \"eventTypeRuleDuration\": null\n                },\n                \"name\": \"Spring 35%\",\n                \"performanceMeasureCondition\": null,\n                \"recurrence\": {\n                    \"daysOfWeek\": [\n                        \"MONDAY\",\n                        \"WEDNESDAY\"\n                    ],\n                    \"intraDaySchedule\": null,\n                    \"type\": \"WEEKLY\"\n                },\n                \"ruleType\": \"SCHEDULE\"\n            },\n            \"ruleId\": \"7788e003-ff0b-4005-bcfb-b68936103a9d\",\n            \"ruleState\": \"ACTIVE\",\n            \"ruleStatus\": \"PENDING_START\",\n            \"ruleStatusDetails\": null\n        }\n    ],\n    \"nextToken\": null\n}"
+								}
+							]
+						},
+						{
+							"name": "Update budget rules",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									},
+									{
+										"key": "",
+										"value": "",
+										"type": "default",
+										"disabled": true
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"budgetRulesDetails\": [\n    {\n      \"lastUpdatedDate\": null,\n      \"ruleDetails\": {\n        \"ruleType\": \"PERFORMANCE\",\n        \"name\": \"Spring Budget Rule - Updated\",\n        \"duration\": {\n          \"dateRangeTypeRuleDuration\": {\n            \"startDate\": \"20230220\",\n            \"endDate\": \"20230308\"\n          }\n        },\n        \"recurrence\": {\n          \"type\": \"DAILY\"\n        },\n        \"budgetIncreaseBy\": {\n          \"type\": \"PERCENT\",\n          \"value\": 75\n        },\n        \"performanceMeasureCondition\": {\n          \"metricName\": \"ROAS\",\n          \"comparisonOperator\": \"GREATER_THAN_OR_EQUAL_TO\",\n          \"threshold\": 2.0\n        }\n      },\n      \"ruleId\": \"{{budgetRuleId}}\",\n      \"ruleState\": \"ACTIVE\",\n      \"ruleStatus\": \"ACTIVE\",\n      \"ruleStatusDetails\": null\n    }\n  ]\n}"
+								},
+								"url": {
+									"raw": "{{api_url}}/sp/budgetRules",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sp",
+										"budgetRules"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Update budget rule state",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"budgetRulesDetails\": [\n    {\n      \"ruleId\": \"{{budgetRuleId}}\",\n      \"ruleState\": \"PAUSED\"\n    }\n  ]\n}"
+										},
+										"url": {
+											"raw": "{{api_url}}/sb/budgetRules",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sb",
+												"budgetRules"
+											]
+										}
+									},
+									"status": "Multi-Status (WebDAV) (RFC 4918)",
+									"code": 207,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:34:13 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "8K4HF8R5CZ63TJGD9XGH"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "13a1855b-2f0d-44f0-a3ef-9f76dad90788"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "8K4HF8R5CZ63TJGD9XGH"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:34:13 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq5EXEJ9oAMFpSg="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f43bb5-b4fab5835f0b8b7a6d3ee464"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:34:13 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"responses\": [\n        {\n            \"associatedCampaignIds\": null,\n            \"code\": \"Ok\",\n            \"details\": \"Budget rule updated\",\n            \"ruleId\": \"19b62c40-0f4a-4995-adfb-a921808e7788\"\n        }\n    ]\n}"
+								},
+								{
+									"name": "Update name, end date, increase value",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"budgetRulesDetails\": [\n    {\n      \"lastUpdatedDate\": null,\n      \"ruleDetails\": {\n        \"ruleType\": \"PERFORMANCE\",\n        \"name\": \"Spring Budget Rule - Updated\",\n        \"duration\": {\n          \"dateRangeTypeRuleDuration\": {\n            \"startDate\": \"20230220\",\n            \"endDate\": \"20230308\"\n          }\n        },\n        \"recurrence\": {\n          \"type\": \"DAILY\"\n        },\n        \"budgetIncreaseBy\": {\n          \"type\": \"PERCENT\",\n          \"value\": 75\n        },\n        \"performanceMeasureCondition\": {\n          \"metricName\": \"ROAS\",\n          \"comparisonOperator\": \"GREATER_THAN_OR_EQUAL_TO\",\n          \"threshold\": 2.0\n        }\n      },\n      \"ruleId\": \"{{budgetRuleId}}\",\n      \"ruleState\": \"ACTIVE\",\n      \"ruleStatus\": \"ACTIVE\",\n      \"ruleStatusDetails\": null\n    }\n  ]\n}"
+										},
+										"url": {
+											"raw": "{{api_url}}/sb/budgetRules",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sb",
+												"budgetRules"
+											]
+										}
+									},
+									"status": "Multi-Status (WebDAV) (RFC 4918)",
+									"code": 207,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:34:41 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "39906RCGEJWB19ECME8F"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "3244ad2f-9828-4196-8b44-95998aaf3c42"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "39906RCGEJWB19ECME8F"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:34:41 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "139"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq5IzFQIIAMFwTw="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f43bd1-892eb2fca796ee363b3ac777"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:34:41 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"responses\": [\n        {\n            \"associatedCampaignIds\": null,\n            \"code\": \"Ok\",\n            \"details\": \"Budget rule updated\",\n            \"ruleId\": \"19b62c40-0f4a-4995-adfb-a921808e7788\"\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "Disassociate budget rule from campaign",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									}
+								],
+								"url": {
+									"raw": "{{api_url}}/sb/campaigns/:campaignId/budgetRules/:budgetRuleId",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sb",
+										"campaigns",
+										":campaignId",
+										"budgetRules",
+										":budgetRuleId"
+									],
+									"variable": [
+										{
+											"key": "campaignId",
+											"value": "{{campaignId}}"
+										},
+										{
+											"key": "budgetRuleId",
+											"value": "{{budgetRuleId}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/sb/campaigns/:campaignId/budgetRules/:budgetRuleId",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sb",
+												"campaigns",
+												":campaignId",
+												"budgetRules",
+												":budgetRuleId"
+											],
+											"variable": [
+												{
+													"key": "campaignId",
+													"value": "{{campaignId}}"
+												},
+												{
+													"key": "budgetRuleId",
+													"value": "{{budgetRuleId}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:40:42 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "3"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "V415VF5CACFFCM3M886M"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "21970933-eebe-44c8-8b42-13cab6ea2264"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "V415VF5CACFFCM3M886M"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:40:42 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "3"
+										},
+										{
+											"key": "x-amzn-Remapped-Connection",
+											"value": "close"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq6BHHveoAMFQWw="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f43d3a-09fbed25080f80728cb6d89a"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:40:41 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{}"
+								}
+							]
+						},
+						{
+							"name": "Campaigns associated with a rule",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									}
+								],
+								"url": {
+									"raw": "{{api_url}}/sb/budgetRules/:budgetRuleId/campaigns?pageSize=30",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sb",
+										"budgetRules",
+										":budgetRuleId",
+										"campaigns"
+									],
+									"query": [
+										{
+											"key": "pageSize",
+											"value": "30"
+										},
+										{
+											"key": "nextToken",
+											"value": null,
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "budgetRuleId",
+											"value": "{{budgetRuleId}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Campaigns associated with a rule",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/sb/budgetRules/:budgetRuleId/campaigns?pageSize=30",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sb",
+												"budgetRules",
+												":budgetRuleId",
+												"campaigns"
+											],
+											"query": [
+												{
+													"key": "pageSize",
+													"value": "30"
+												},
+												{
+													"key": "nextToken",
+													"value": null,
+													"disabled": true
+												}
+											],
+											"variable": [
+												{
+													"key": "budgetRuleId",
+													"value": "{{budgetRuleId}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:41:04 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "151"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "5Z73H1FE77HQ47B2SYKV"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "ac271a72-3a20-4fda-a82a-5ed3196ca6e0"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "5Z73H1FE77HQ47B2SYKV"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:41:04 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "151"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq6EnGM9IAMFkSQ="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f43d50-f9fb4311a045ed81c20d25d4"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:41:04 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"associatedCampaigns\": [\n        {\n            \"campaignId\": \"38789817437281\",\n            \"campaignName\": \"Campaign - 2/20/2023 22:26:18\",\n            \"ruleStatus\": \"PENDING_START\"\n        }\n    ],\n    \"nextToken\": null\n}"
+								}
+							]
+						},
+						{
+							"name": "Budget rule by ID",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									}
+								],
+								"url": {
+									"raw": "{{api_url}}/sb/budgetRules/:budgetRuleId",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sb",
+										"budgetRules",
+										":budgetRuleId"
+									],
+									"variable": [
+										{
+											"key": "budgetRuleId",
+											"value": "{{budgetRuleId}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/sb/budgetRules/:budgetRuleId",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sb",
+												"budgetRules",
+												":budgetRuleId"
+											],
+											"variable": [
+												{
+													"key": "budgetRuleId",
+													"value": "{{budgetRuleId}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:35:44 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "618"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "MQ3YKQ4EZ1Q2VEF6NGKX"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "20156d64-ae45-467c-b683-27a7933c0a5c"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "MQ3YKQ4EZ1Q2VEF6NGKX"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:35:44 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "618"
+										},
+										{
+											"key": "x-amzn-Remapped-Connection",
+											"value": "close"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq5SmG2zIAMFg1Q="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f43c10-3c298fba32c77b36ec2b8198"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:35:44 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"budgetRule\": {\n        \"createdDate\": 1676949831857,\n        \"lastUpdatedDate\": null,\n        \"ruleDetails\": {\n            \"budgetIncreaseBy\": {\n                \"type\": \"PERCENT\",\n                \"value\": 75\n            },\n            \"duration\": {\n                \"dateRangeTypeRuleDuration\": {\n                    \"endDate\": \"20230308\",\n                    \"startDate\": \"20230220\"\n                },\n                \"eventTypeRuleDuration\": null\n            },\n            \"name\": \"Spring Budget Rule - Updated\",\n            \"performanceMeasureCondition\": {\n                \"comparisonOperator\": \"GREATER_THAN_OR_EQUAL_TO\",\n                \"metricName\": \"ROAS\",\n                \"threshold\": 2\n            },\n            \"recurrence\": {\n                \"daysOfWeek\": null,\n                \"intraDaySchedule\": null,\n                \"type\": \"DAILY\"\n            },\n            \"ruleType\": \"PERFORMANCE\"\n        },\n        \"ruleId\": \"19b62c40-0f4a-4995-adfb-a921808e7788\",\n        \"ruleState\": \"ACTIVE\",\n        \"ruleStatus\": \"ACTIVE\",\n        \"ruleStatusDetails\": null\n    }\n}"
+								}
+							]
+						},
+						{
+							"name": "Rules associated with a campaign",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "default"
+									},
+									{
+										"key": "",
+										"value": "",
+										"type": "default",
+										"disabled": true
+									}
+								],
+								"url": {
+									"raw": "{{api_url}}/sb/campaigns/:campaignId/budgetRules",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sb",
+										"campaigns",
+										":campaignId",
+										"budgetRules"
+									],
+									"query": [
+										{
+											"key": "nextToken",
+											"value": null,
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "campaignId",
+											"value": "{{campaignId}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "Success",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-Scope",
+												"value": "{{profileId}}",
+												"type": "default"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "default"
+											},
+											{
+												"key": "",
+												"value": "",
+												"type": "default",
+												"disabled": true
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/sb/campaigns/:campaignId/budgetRules",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"sb",
+												"campaigns",
+												":campaignId",
+												"budgetRules"
+											],
+											"query": [
+												{
+													"key": "nextToken",
+													"value": null,
+													"disabled": true
+												}
+											],
+											"variable": [
+												{
+													"key": "campaignId",
+													"value": "{{campaignId}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Server",
+											"value": "Server"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 21 Feb 2023 03:36:32 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "598"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "x-amz-rid",
+											"value": "E9GR3VCG9XZ417XVABTD"
+										},
+										{
+											"key": "x-amzn-RequestId",
+											"value": "3cc8567b-c7a7-4525-be03-058e573c66ad"
+										},
+										{
+											"key": "x-amzn-Remapped-x-amzn-RequestId",
+											"value": "E9GR3VCG9XZ417XVABTD"
+										},
+										{
+											"key": "X-Amz-Date",
+											"value": "Tue, 21 Feb 2023 03:36:32 GMT"
+										},
+										{
+											"key": "x-amzn-Remapped-Content-Length",
+											"value": "598"
+										},
+										{
+											"key": "x-amz-apigw-id",
+											"value": "Aq5aBGs0IAMF2iQ="
+										},
+										{
+											"key": "x-amzn-Remapped-Server",
+											"value": "Apache-Coyote/1.1"
+										},
+										{
+											"key": "X-Amzn-Trace-Id",
+											"value": "Root=1-63f43c40-1ffb48b6ce994ffd25d26419"
+										},
+										{
+											"key": "x-amzn-Remapped-Date",
+											"value": "Tue, 21 Feb 2023 03:36:31 GMT"
+										},
+										{
+											"key": "Vary",
+											"value": "Content-Type,Accept-Encoding,User-Agent"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=47474747; includeSubDomains; preload"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"associatedRules\": [\n        {\n            \"createdDate\": 1676949721783,\n            \"lastUpdatedDate\": 1676949721783,\n            \"ruleDetails\": {\n                \"budgetIncreaseBy\": {\n                    \"type\": \"PERCENT\",\n                    \"value\": 35\n                },\n                \"duration\": {\n                    \"dateRangeTypeRuleDuration\": {\n                        \"endDate\": \"20230430\",\n                        \"startDate\": \"20230301\"\n                    },\n                    \"eventTypeRuleDuration\": null\n                },\n                \"name\": \"Spring 35%\",\n                \"performanceMeasureCondition\": null,\n                \"recurrence\": {\n                    \"daysOfWeek\": [\n                        \"MONDAY\",\n                        \"WEDNESDAY\"\n                    ],\n                    \"intraDaySchedule\": null,\n                    \"type\": \"WEEKLY\"\n                },\n                \"ruleType\": \"SCHEDULE\"\n            },\n            \"ruleId\": \"7788e003-ff0b-4005-bcfb-b68936103a9d\",\n            \"ruleState\": \"ACTIVE\",\n            \"ruleStatus\": \"PENDING_START\",\n            \"ruleStatusDetails\": {\n                \"reasonCode\": null,\n                \"status\": \"PENDING_START\"\n            }\n        }\n    ]\n}"
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Budget usage",
+			"item": [
+				{
+					"name": "Sponsored Products",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Amazon-Advertising-API-ClientId",
+								"value": "{{client_id}}",
+								"type": "text"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{access_token}}",
+								"type": "text"
+							},
+							{
+								"key": "Amazon-Advertising-API-Scope",
+								"value": "{{profileId}}",
+								"type": "default"
+							},
+							{
+								"key": "Accept",
+								"value": "application/vnd.spcampaignbudgetusage.v1+json",
+								"type": "default"
+							},
+							{
+								"key": "",
+								"value": "",
+								"type": "default",
+								"disabled": true
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"campaignIds\": [\n    \"{{campaignId}}\"\n  ]\n}"
+						},
+						"url": {
+							"raw": "{{api_url}}/sp/campaigns/budget/usage",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"sp",
+								"campaigns",
+								"budget",
+								"usage"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Success",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									},
+									{
+										"key": "Accept",
+										"value": "application/vnd.spcampaignbudgetusage.v1+json",
+										"type": "default"
+									},
+									{
+										"key": "",
+										"value": "",
+										"type": "default",
+										"disabled": true
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"campaignIds\": [\n    \"{{campaignId}}\"\n  ]\n}"
+								},
+								"url": {
+									"raw": "{{api_url}}/sp/campaigns/budget/usage",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sp",
+										"campaigns",
+										"budget",
+										"usage"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Server",
+									"value": "Server"
+								},
+								{
+									"key": "Date",
+									"value": "Tue, 28 Mar 2023 19:10:23 GMT"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Content-Length",
+									"value": "153"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "x-amz-rid",
+									"value": "N39AEDBWGWRZ02SEVN7S"
+								},
+								{
+									"key": "x-amzn-RequestId",
+									"value": "7edf0cae-072f-4487-9e14-1b15ae406bb5"
+								},
+								{
+									"key": "x-amz-apigw-id",
+									"value": "CgZA-HyfoAMFp5A="
+								},
+								{
+									"key": "X-Amzn-Trace-Id",
+									"value": "Root=1-64233b9f-73e46bf27b04db0cc44ff2ce"
+								},
+								{
+									"key": "Vary",
+									"value": "Content-Type,Accept-Encoding,User-Agent"
+								},
+								{
+									"key": "Strict-Transport-Security",
+									"value": "max-age=47474747; includeSubDomains; preload"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"error\": [],\n    \"success\": [\n        {\n            \"budget\": 10,\n            \"budgetUsagePercent\": 0,\n            \"campaignId\": \"102028944323821\",\n            \"index\": 0,\n            \"usageUpdatedTimestamp\": \"2023-03-28T07:00:00Z\"\n        }\n    ]\n}"
+						}
+					]
+				},
+				{
+					"name": "Sponsored Brands",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Amazon-Advertising-API-ClientId",
+								"value": "{{client_id}}",
+								"type": "text"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{access_token}}",
+								"type": "text"
+							},
+							{
+								"key": "Amazon-Advertising-API-Scope",
+								"value": "{{profileId}}",
+								"type": "default"
+							},
+							{
+								"key": "Accept",
+								"value": "application/vnd.spcampaignbudgetusage.v1+json",
+								"type": "default"
+							},
+							{
+								"key": "",
+								"value": "",
+								"type": "default",
+								"disabled": true
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"campaignIds\": [\n    \"{{campaignId}}\"\n  ]\n}"
+						},
+						"url": {
+							"raw": "{{api_url}}/sp/campaigns/budget/usage",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"sp",
+								"campaigns",
+								"budget",
+								"usage"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Success",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"campaignIds\": [\n    \"{{campaignId}}\"\n  ]\n}"
+								},
+								"url": {
+									"raw": "{{api_url}}/sb/campaigns/budget/usage",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sb",
+										"campaigns",
+										"budget",
+										"usage"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Server",
+									"value": "Server"
+								},
+								{
+									"key": "Date",
+									"value": "Tue, 28 Mar 2023 19:02:09 GMT"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Content-Length",
+									"value": "152"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "x-amz-rid",
+									"value": "X7DGV4H0E2SPHF308X74"
+								},
+								{
+									"key": "x-amzn-RequestId",
+									"value": "3fe6674b-2a88-4350-810c-e825585d5b7d"
+								},
+								{
+									"key": "x-amz-apigw-id",
+									"value": "CgXzsFUbIAMFlQQ="
+								},
+								{
+									"key": "X-Amzn-Trace-Id",
+									"value": "Root=1-642339b1-bd48a4a96ea5c3737c48e5c5"
+								},
+								{
+									"key": "Vary",
+									"value": "Content-Type,Accept-Encoding,User-Agent"
+								},
+								{
+									"key": "Strict-Transport-Security",
+									"value": "max-age=47474747; includeSubDomains; preload"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"error\": [],\n    \"success\": [\n        {\n            \"budget\": 50,\n            \"budgetUsagePercent\": 0,\n            \"campaignId\": \"38789817437281\",\n            \"index\": 0,\n            \"usageUpdatedTimestamp\": \"2023-03-28T07:07:48Z\"\n        }\n    ]\n}"
+						}
+					]
+				},
+				{
+					"name": "Sponsored Display",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Amazon-Advertising-API-ClientId",
+								"value": "{{client_id}}",
+								"type": "text"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{access_token}}",
+								"type": "text"
+							},
+							{
+								"key": "Amazon-Advertising-API-Scope",
+								"value": "{{profileId}}",
+								"type": "default"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"campaignIds\": [\n    \"{{campaignId}}\"\n  ]\n}"
+						},
+						"url": {
+							"raw": "{{api_url}}/sd/campaigns/budget/usage",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"sd",
+								"campaigns",
+								"budget",
+								"usage"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Success",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}",
+										"type": "default"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"campaignIds\": [\n    \"{{campaignId}}\"\n  ]\n}"
+								},
+								"url": {
+									"raw": "{{api_url}}/sd/campaigns/budget/usage",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"sd",
+										"campaigns",
+										"budget",
+										"usage"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Server",
+									"value": "Server"
+								},
+								{
+									"key": "Date",
+									"value": "Tue, 28 Mar 2023 19:03:47 GMT"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Content-Length",
+									"value": "154"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "x-amz-rid",
+									"value": "889RREHY1E5S0PP7JXXQ"
+								},
+								{
+									"key": "x-amzn-RequestId",
+									"value": "6b5456eb-75fb-4941-9181-756e309c39bb"
+								},
+								{
+									"key": "x-amz-apigw-id",
+									"value": "CgYDAHAkIAMF1Hg="
+								},
+								{
+									"key": "X-Amzn-Trace-Id",
+									"value": "Root=1-64233a13-564dfa07c55752d77c58e064"
+								},
+								{
+									"key": "Vary",
+									"value": "Content-Type,Accept-Encoding,User-Agent"
+								},
+								{
+									"key": "Strict-Transport-Security",
+									"value": "max-age=47474747; includeSubDomains; preload"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"error\": [],\n    \"success\": [\n        {\n            \"budget\": 100,\n            \"budgetUsagePercent\": 0,\n            \"campaignId\": \"144765279800494\",\n            \"index\": 0,\n            \"usageUpdatedTimestamp\": \"2023-03-28T07:12:17Z\"\n        }\n    ]\n}"
+						}
+					]
+				}
+			]
 		}
 	],
 	"event": [
@@ -16362,7 +22830,7 @@
 					"}",
 					"",
 					"/**Add custom header containing the collection version to all collection requests*/",
-					"pm.request.headers.add({key: 'Postman-Collection', value: 'Amazon-Ads-API-v1.4'}) "
+					"pm.request.headers.add({key: 'Postman-Collection', value: 'Amazon-Ads-API-v1.5'}) "
 				]
 			}
 		},

--- a/postman/README.md
+++ b/postman/README.md
@@ -11,14 +11,19 @@ Visit the [Amazon Ads advanced tools center](https://advertising.amazon.com/API/
 The Amazon Ads API Postman collection currently supports the following features:
 
 - Authentication
+- GET profiles
+- GET manager accounts
 - Sponsored Products campaign management (version 3)
 - Sponsored ads reporting
     - Version 3
     - Version 2
+- DSP reporting
 - Sponsored ads snapshots 
 - Test accounts
 - Amazon Marketing Stream beta
 - Product metadata 
+- Sponsored ads budget usage
+- Sponsored ads budget rules
 
 ## Setup
 


### PR DESCRIPTION
*Description of changes:*
- adds budget rules (SP, SB, SD) to Postman collection
- adds budget usage (SP, SB, SD) to Postman collection
- updates SB list campaigns to use new V4 endpoints

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
