### PR TITLE
Add firehose and cloudwatch docs

### DIFF
--- a/amazon_marketing_stream/README.md
+++ b/amazon_marketing_stream/README.md
@@ -3,5 +3,7 @@
 This folder contains developer resources related to Amazon Marketing Stream, including:
 
 - CloudFormation template to create SQS queues
+- CloudFormation template to create Firehose streams
+- CloudFormation template to create CloudWatch alarms and dashboards
 
 To learn more about using the CloudFormation template, see [CloudFormation onboarding instructions](https://advertising.amazon.com/API/docs/en-us/amazon-marketing-stream/cloud-formation)

--- a/amazon_marketing_stream/Stream_CloudWatch_CF_Template.yaml
+++ b/amazon_marketing_stream/Stream_CloudWatch_CF_Template.yaml
@@ -1,0 +1,182 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  This CloudFormation template creates a CloudWatch dashboard, SNS topic, alarms
+  for monitoring an Amazon SQS queue. It takes the SQS queue name and email address as input parameters.
+
+Parameters:
+  SQSQueueName:
+    Type: String
+    Description: The name of the Amazon SQS queue to monitor.
+  EmailAddress:
+    Type: String
+    Description: The email address to receive notifications.
+
+Resources:
+  SNSTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      Subscription:
+        - Endpoint: !Ref EmailAddress
+          Protocol: email
+
+  SQSQueueDashboard:
+    Type: AWS::CloudWatch::Dashboard
+    Properties:
+      DashboardName: !Sub 'SQS-Queue-${SQSQueueName}-Monitoring'
+      DashboardBody: !Sub |
+        {
+          "widgets": [
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "AWS/SQS", "ApproximateNumberOfMessagesVisible", "QueueName", "${SQSQueueName}" ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${AWS::Region}",
+                "title": "Messages in Queue",
+                "stat": "Sum",
+                "period": 300
+              }
+            },
+            {
+              "type": "metric",
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "AWS/SQS", "ApproximateAgeOfOldestMessage", "QueueName", "${SQSQueueName}" ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${AWS::Region}",
+                "title": "Age of Oldest Message",
+                "stat": "Maximum",
+                "period": 300
+              }
+            },
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 6,
+              "width": 24,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "AWS/SQS", "NumberOfMessagesDeleted", "QueueName", "${SQSQueueName}" ],
+                  [ ".", "NumberOfMessagesSent", ".", "." ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${AWS::Region}",
+                "title": "Messages Deleted and Sent",
+                "stat": "Sum",
+                "period": 300
+              }
+            }
+          ]
+        }
+
+  MessageVisibleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub 'SQS-Queue-${SQSQueueName}-MessageVisibleAlarm'
+      AlarmDescription: 'Alarm for a high number of visible messages in the SQS queue'
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Statistic: Maximum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 10000
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: QueueName
+          Value: !Ref SQSQueueName
+      AlarmActions:
+        - !Ref SNSTopic
+      # This alarm is triggered when the number of visible messages in the queue exceeds 10,000.
+      # The threshold of 10,000 is based on the assumption that a backlog of more than 10,000 messages
+      # could indicate that your application is unable to keep up, and processing is getting delayed significantly.
+      # This threshold should be adjusted based on your expected maximum queue size and traffic patterns.
+
+  OldestMessageAgeAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub 'SQS-Queue-${SQSQueueName}-OldestMessageAgeAlarm'
+      AlarmDescription: 'Alarm for a high age of the oldest message in the SQS queue'
+      MetricName: ApproximateAgeOfOldestMessage
+      Namespace: AWS/SQS
+      Statistic: Maximum
+      Period: 3600
+      EvaluationPeriods: 1
+      Threshold: 3600 # Threshold set to 1 hour (3600 seconds)
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: QueueName
+          Value: !Ref SQSQueueName
+      AlarmActions:
+        - !Ref SNSTopic
+      # This alarm is triggered when the age of the oldest message in the queue exceeds 1 hour (3600 seconds).
+      # The one-hour processing threshold is set because Amazon marketing data is typically delivered hourly. We expect messages to be processed within this timeframe. 
+      # having a message stuck for over 1 hour indicates an issue worth investigating.
+      # This threshold can be adjusted based on your expected message processing times.
+
+  MessageDeletedDivergenceAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub 'SQS-Queue-${SQSQueueName}-MessageDeletedDivergenceAlarm'
+      AlarmDescription: 'Alert when a significant divergence is observed between the number of messages sent to the queue and the number of messages deleted from the queue within an hour. This could indicate an issue with your application processing messages successfully.'
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: e1
+          Expression: 'IF((m1-m2) > 100,1,0)'
+          Label: MessageDeletedDivergenceAlarm
+          # This expression evaluates to 1 (alarm state) if the difference between the number of messages sent (m1)
+          # and the number of messages deleted (m2) exceeds 100 within the evaluation period (1 hour).
+          # This is based on the assumption that a significant divergence between sent and deleted messages
+          # could indicate an issue with your application processing messages successfully.
+        - Id: m1
+          MetricStat:
+            Metric:
+              Namespace: AWS/SQS
+              MetricName: NumberOfMessagesSent
+              Dimensions:
+                - Name: QueueName
+                  Value: !Ref SQSQueueName
+            Period: 3600 # Evaluation period is 1 hour (3600 seconds)
+            Stat: Minimum
+            Unit: Count
+          ReturnData: false
+        - Id: m2
+          MetricStat:
+            Metric:
+              Namespace: AWS/SQS
+              MetricName: NumberOfMessagesDeleted
+              Dimensions:
+                - Name: QueueName
+                  Value: !Ref SQSQueueName
+            Period: 3600 # Evaluation period is 1 hour (3600 seconds)
+            Stat: Minimum
+            Unit: Count
+          ReturnData: false
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      # The alarm is triggered if the result of the expression (e1) is greater than or equal to 1.
+      # This is based on the assumption that messages are expected to be processed every hour, as Amazon Marketing Stream is meant for hourly data.
+      # If your processing cycle is different, please adjust the threshold and evaluation period accordingly.
+
+Outputs:
+  DashboardURL:
+    Description: The URL of the CloudWatch dashboard
+    Value: !Sub 'https://${AWS::Region}.console.aws.amazon.com/cloudwatch/home?region=${AWS::Region}#dashboards:name=${SQSQueueDashboard}'
+  SNSTopicArn:
+    Description: The ARN of the SNS topic
+    Value: !Ref SNSTopic

--- a/amazon_marketing_stream/Stream_Firehose_CF_Template.yaml
+++ b/amazon_marketing_stream/Stream_Firehose_CF_Template.yaml
@@ -1,0 +1,365 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Parameters:
+  StreamDestinationFirehose:
+    Type: String
+    Description: Name of the data stream for receiving data
+    Default: StreamDestinationFirehoseDefaultName
+
+  StreamDatasetId:
+    Type: String
+    Description: Please select the stream dataset for which you wish to receive the data
+    AllowedValues:
+      - sp-traffic
+      - sp-conversion
+      - budget-usage
+      - sd-traffic      
+      - sd-conversion
+      - sponsored-ads-campaign-diagnostics-recommendations
+      - campaigns
+      - adgroups
+      - ads
+      - targets
+      - sb-traffic
+      - sb-conversion
+      - sb-clickstream
+      - sb-rich-media
+      - adsp-campaigns
+      - adsp-campaign-flights
+      - adsp-adgroups
+      - adsp-adgroup-targets
+      - sp-budget-recommendations
+
+  StreamRealm:
+    Type: String
+    Description: Select the aws region for your stream destination
+    AllowedValues:
+      - NA
+      - EU
+      - FE
+      
+  S3Storage:
+    Description: Choose a unique S3 bucket name for your stream destination
+    Type: String
+    MinLength: 1
+    MaxLength: 255
+    AllowedPattern: '^[a-zA-Z][-a-zA-Z0-9]*$'
+Mappings:
+  Region:
+    NA:
+      Region: us-east-1
+    EU:
+      Region: eu-west-1
+    FE:
+      Region: us-west-2
+
+  NA:
+    sp-traffic:
+      Account: 906013806264
+    sp-conversion:
+      Account: 802324068763
+    budget-usage:
+      Account: 055588217351
+    sd-traffic:
+      Account: 370941301809
+    sd-conversion:
+      Account: 877712924581
+    sponsored-ads-campaign-diagnostics-recommendations:
+      Account: 084590724871
+    campaigns:
+      Account: 570159413969
+    adgroups:
+      Account: 118846437111
+    ads:
+      Account: 305370293182
+    targets:
+      Account: 644124924521
+    sb-traffic:
+      Account: 709476672186
+    sb-conversion: 
+      Account: 154357381721
+    sb-clickstream:
+      Account: 091028706140
+    sb-rich-media:
+      Account: 010312603579
+    adsp-campaigns:
+      Account: 153247821255
+    adsp-campaign-flights:
+      Account: 700228448367
+    adsp-adgroups:
+      Account: 222778752755
+    adsp-adgroup-targets:
+      Account: 419834811630
+    sp-budget-recommendations:
+      Account: 678715897637
+  EU:
+    sp-traffic:
+      Account: 668473351658
+    sp-conversion:
+      Account: 562877083794
+    budget-usage:
+      Account: 675750596317
+    sd-traffic:
+      Account: 947153514089
+    sd-conversion:
+      Account: 664093967423 
+    sponsored-ads-campaign-diagnostics-recommendations:
+      Account: 059061853903
+    campaigns:
+      Account: 834862128520
+    adgroups:
+      Account: 130948361130
+    ads:
+      Account: 648558082147
+    targets:
+      Account: 503759481754
+    sb-traffic:
+      Account: 623198756881
+    sb-conversion: 
+      Account: 195770945541
+    sb-clickstream:
+      Account: 219513501272
+    sb-rich-media:
+      Account: 662188760626
+    adsp-campaigns:
+      Account: 599052634802
+    adsp-campaign-flights:
+      Account: 633559263003
+    adsp-adgroups:
+      Account: 682324742468
+    adsp-adgroup-targets:
+      Account: 764057072099
+    sp-budget-recommendations:
+      Account: 158915609581
+  FE:
+    sp-traffic:
+      Account: 074266271188
+    sp-conversion:
+      Account: 622939981599
+    budget-usage:
+      Account: 100899330244
+    sd-traffic:
+      Account: 310605068565
+    sd-conversion:
+      Account: 818973306977
+    sponsored-ads-campaign-diagnostics-recommendations:
+      Account: 489995134625
+    campaigns:
+      Account: 527383333093
+    adgroups:
+      Account: 668585072850
+    ads:
+      Account: 802070757281
+    targets:
+      Account: 248074939493
+    sb-traffic:
+      Account: 485899199471
+    sb-conversion: 
+      Account: 112347756703
+    sb-clickstream:
+      Account: 632322331982
+    sb-rich-media:
+      Account: 618223300352
+    adsp-campaigns:
+      Account: 216875695489
+    adsp-campaign-flights:
+      Account: 451213518288
+    adsp-adgroups:
+      Account: 360850786875
+    adsp-adgroup-targets:
+      Account: 178122609971
+    sp-budget-recommendations:
+      Account: 007292432803
+Rules:
+  NA:
+    RuleCondition:
+      Fn::Equals: [ !Ref StreamRealm, NA ]
+    Assertions:
+      - Assert:
+          Fn::Equals: [ !Ref AWS::Region, us-east-1 ]
+  EU:
+    RuleCondition:
+      Fn::Equals: [ !Ref StreamRealm, EU ]
+    Assertions:
+      - Assert:
+          Fn::Equals: [ !Ref AWS::Region, eu-west-1 ]
+  FE:
+    RuleCondition:
+      Fn::Equals: [ !Ref StreamRealm, FE ]
+    Assertions:
+      - Assert:
+          Fn::Equals: [ !Ref AWS::Region, us-west-2 ]
+Resources:
+  StreamDestinationFirehoseName:
+    Type: 'AWS::KinesisFirehose::DeliveryStream'
+    Properties:
+      DeliveryStreamName: !Sub ${StreamRealm}-${StreamDatasetId}-${StreamDestinationFirehose}
+      DeliveryStreamType: 'DirectPut'
+      ExtendedS3DestinationConfiguration:
+        BucketARN: !GetAtt S3Bucket.Arn
+        BufferingHints:
+          SizeInMBs: 5
+          IntervalInSeconds: 300
+        CloudWatchLoggingOptions:
+          Enabled: true
+          LogGroupName: !Sub ${StreamRealm}-${StreamDatasetId}-${StreamDestinationFirehose}l-extendedS3-log
+          LogStreamName: 'S3Delivery'
+        CompressionFormat: 'UNCOMPRESSED'
+        Prefix: !Join
+          - ''
+          - - !Ref StreamDestinationFirehose
+            - '/year=!{timestamp:YYYY}/month=!{timestamp:MM}/day=!{timestamp:dd}/hour=!{timestamp:HH}/'
+        ErrorOutputPrefix: !Join
+          - ''
+          - - !Ref StreamDestinationFirehose
+            - 'error/!{firehose:error-output-type}/year=!{timestamp:YYYY}/month=!{timestamp:MM}/day=!{timestamp:dd}/hour=!{timestamp:HH}/'
+
+        RoleARN: !GetAtt FirehoseDeliveryRole.Arn
+        ProcessingConfiguration:
+          Enabled: false
+        S3BackupMode: 'Disabled'
+  S3Bucket:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: !Ref S3Storage
+
+  FirehoseDeliveryRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Join ['-', [!Ref StreamRealm, !Ref StreamDatasetId, FirehoseDeliveryRole]]
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Effect: Allow
+          Principal:
+            Service: firehose.amazonaws.com
+          Action: 'sts:AssumeRole'
+
+  FirehoseDeliveryPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Join ['-', [!Ref StreamRealm, !Ref StreamDatasetId, FirehoseDeliveryPolicy]] 
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - 's3:AbortMultipartUpload'
+              - 's3:GetBucketLocation'
+              - 's3:GetObject'
+              - 's3:ListBucket'
+              - 's3:ListBucketMultipartUploads'
+              - 's3:PutObject'
+            Resource: !Join
+              - ''
+              - - 'arn:aws:s3:::'
+                - !Sub '${S3Storage}'
+                - '/*'
+          - Effect: Allow
+            Action: 'logs:PutLogEvents'
+            Resource:
+              - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/kinesisfirehose/${StreamDestinationFirehose}:log-stream:*'
+
+      Roles:
+        - !Ref FirehoseDeliveryRole
+
+  FirehoseSubscriptionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Join ['-', [!Ref StreamRealm, !Ref StreamDatasetId, FirehoseSubscriptionRole]] 
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: sns.amazonaws.com
+          Action: 'sts:AssumeRole'
+        - Effect: Allow
+          Principal:
+            AWS:
+             - arn:aws:iam::926844853897:role/ReviewerRole
+          Action: 'sts:AssumeRole'
+
+  FirehoseSubscriptionRolePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Join ['-', [!Ref StreamRealm, !Ref StreamDatasetId, FirehoseSubscriptionRolePolicy]]
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+             - firehose:DescribeDeliveryStream
+             - firehose:ListTagsForDeliveryStream
+             - firehose:ListDeliveryStreams
+             - firehose:PutRecord
+             - firehose:PutRecordBatch
+            Resource: !GetAtt StreamDestinationFirehoseName.Arn
+      Roles:
+        - !Ref FirehoseSubscriptionRole
+
+  
+  FirehoseSubscriberRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Join ['-', [!Ref StreamRealm, !Ref StreamDatasetId, FirehoseSubscriberRole]]
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Effect: Allow
+          Principal:
+            AWS:
+             - arn:aws:iam::926844853897:role/SubscriberRole
+          Action: 
+            - sts:AssumeRole
+            - sts:TagSession
+
+  FirehoseSubscriberRolePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Join ['-', [!Ref StreamRealm, !Ref StreamDatasetId, FirehoseSubscriberRolePolicy]]
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+             - iam:PassRole
+            Resource: !GetAtt FirehoseSubscriptionRole.Arn
+          - Effect: Allow
+            Action: 
+              - sns:Subscribe
+              - sns:Unsubscribe
+            Resource: !Join 
+              - ':'
+              - - "arn:aws:sns"
+                - !FindInMap 
+                  - Region
+                  - !Ref 'StreamRealm'
+                  - Region
+                - !FindInMap 
+                  - !Ref 'StreamRealm'
+                  - !Ref 'StreamDatasetId'
+                  - Account
+                - "*"
+      Roles:
+        - !Ref FirehoseSubscriberRole
+
+Outputs:
+  StreamDestinationFirehoseName:
+    Value: !Ref StreamDestinationFirehoseName
+
+  S3Bucket:
+    Value:
+      Fn::GetAtt: [S3Bucket, Arn]
+
+  FirehoseDeliveryRole:
+    Value: !Ref FirehoseDeliveryRole
+
+  FirehoseSubscriptionRole:
+    Value:
+      Fn::GetAtt: [FirehoseSubscriptionRole, Arn]
+
+  FirehoseSubscriberRole:
+    Value:
+      Fn::GetAtt: [FirehoseSubscriberRole, Arn]
+

--- a/postman/Amazon_Ads_API.postman_collection.json
+++ b/postman/Amazon_Ads_API.postman_collection.json
@@ -1,9 +1,10 @@
 {
 	"info": {
-		"_postman_id": "9b76ce81-9aca-4bf8-b695-04ad2c272907",
+		"_postman_id": "20a77764-f77c-4e43-babf-d46a8e3f7999",
 		"name": "Amazon Ads API",
 		"description": "# Amazon Ads API Postman collection\n\nThis collection includes commonly used endpoints for the Amazon Ads API. The collection also includes pre- and post-request scripts to automate management of auth credentials.\n\nVisit the [Amazon Ads advanced tools center](https://advertising.amazon.com/API/docs/en-us/) for API documentation.\n\n## Setup\n\nTo use this collection, you will need credentials for the Amazon Ads API. For information about acquiring credentials, see the [onboarding overview for the Amazon Ads API](https://advertising.amazon.com/API/docs/en-us/onboarding/overview).\n\nFind setup instructions in the Amazon Ads advanced tools center for:\n\n- [New users of the Amazon Ads API](https://advertising.amazon.com/API/docs/en-us/getting-started/using-postman-collection)\n- [Users with an existing refresh token](https://advertising.amazon.com/API/docs/en-us/tutorials/postman) \n\n## Issues and support\n\nFor technical support for the Amazon Ads API, see [Technical support](https://advertising.amazon.com/API/docs/en-us/info/support) in the Amazon Ads advanced tools center.\n\nTo report a bug or suggest an improvement relating to this collection or the documentation, [create an issue](https://github.com/amzn/ads-advanced-tools-docs/issues/new/choose).",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "28917689"
 	},
 	"item": [
 		{
@@ -5844,7 +5845,7 @@
 					},
 					"response": [
 						{
-							"name": "sp-traffic",
+							"name": "sp-traffic + SQS",
 							"originalRequest": {
 								"method": "POST",
 								"header": [
@@ -5897,7 +5898,7 @@
 							"body": "{\n  \"clientRequestToken\": \"stream-sp-traffic-test-123456\",\n  \"subscriptionId\": \"xxxxxxxxxxxxxxx\"\n}"
 						},
 						{
-							"name": "sp-conversion",
+							"name": "sp-conversion + SQS",
 							"originalRequest": {
 								"method": "POST",
 								"header": [
@@ -5950,7 +5951,7 @@
 							"body": "{\n  \"clientRequestToken\": \"stream-sp-conversion-test-123456\",\n  \"subscriptionId\": \"xxxxxxxxxxxxxxx\"\n}"
 						},
 						{
-							"name": "budget-usage",
+							"name": "budget-usage +SQS",
 							"originalRequest": {
 								"method": "POST",
 								"header": [
@@ -6001,6 +6002,107 @@
 							],
 							"cookie": [],
 							"body": "{\n  \"clientRequestToken\": \"stream-budget-usage-test-123456\",\n  \"subscriptionId\": \"xxxxxxxxxxxxxxx\"\n}"
+						},
+						{
+							"name": "sp-conversion + Firehose",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"description": "(Required) The identifier of a client associated with a \"Login with Amazon\" account.",
+										"key": "Amazon-Advertising-API-ClientId",
+										"value": "{{client_id}}"
+									},
+									{
+										"description": "(Required) The identifier of a profile associated with the advertiser account. Use GET method on Profiles resource to list profiles associated with the access token passed in the HTTP Authorization header.",
+										"key": "Amazon-Advertising-API-Scope",
+										"value": "{{profileId}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.MarketingStreamSubscriptions.StreamSubscriptionResource.v1.0+json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/vnd.MarketingStreamSubscriptions.StreamSubscriptionResource.v1.0+json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "default"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"clientRequestToken\": \"stringstringstringstri\",\n  \"dataSetId\": \"sp-conversion\",\n  \"destination\": {\n    \"firehoseDestination\": {\n      \"deliveryStreamArn\": \"arn:aws:firehose:us-east-1:379073720614:deliverystream/NA-sp-conversion-StreamDestinationFirehoseSpConversionNA\",\n      \"subscriptionRoleArn\": \"arn:aws:iam::379073720614:role/NA-sp-conversion-FirehoseSubscriptionRole\",\n      \"subscriberRoleArn\": \"arn:aws:iam::379073720614:role/NA-sp-conversion-FirehoseSubscriberRole\"\n    }\n  }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{api_url}}/streams/subscriptions",
+									"host": [
+										"{{api_url}}"
+									],
+									"path": [
+										"streams",
+										"subscriptions"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Server",
+									"value": "Server"
+								},
+								{
+									"key": "Date",
+									"value": "Wed, 01 May 2024 21:03:47 GMT"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Content-Length",
+									"value": "104"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "x-amz-rid",
+									"value": "CV02QTEGW2ADTDPMSES4"
+								},
+								{
+									"key": "x-amzn-RequestId",
+									"value": "819e2bb1-84f1-45ca-bd75-ac2e23a77807"
+								},
+								{
+									"key": "x-amz-apigw-id",
+									"value": "XHAoDHdRIAMFSfQ="
+								},
+								{
+									"key": "X-Amzn-Trace-Id",
+									"value": "Root=1-6632ae33-c822441a9fb54a1bba1a8969"
+								},
+								{
+									"key": "Vary",
+									"value": "Content-Type,Accept-Encoding,User-Agent"
+								},
+								{
+									"key": "Strict-Transport-Security",
+									"value": "max-age=47474747; includeSubDomains; preload"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"clientRequestToken\": \"stringstringstringstri\",\n    \"subscriptionId\": \"amzn1.fead.cs1.kDOCOan12sYjMoSFVNZLHg\"\n}"
 						}
 					]
 				},
@@ -6059,14 +6161,16 @@
 								"method": "GET",
 								"header": [
 									{
-										"description": "(Required) The identifier of a client associated with a \"Login with Amazon\" account.",
 										"key": "Amazon-Advertising-API-ClientId",
-										"value": "aliquip cillum officia ea"
+										"value": "{{client_id}}"
 									},
 									{
-										"description": "(Required) The identifier of a profile associated with the advertiser account. Use GET method on Profiles resource to list profiles associated with the access token passed in the HTTP Authorization header.",
 										"key": "Amazon-Advertising-API-Scope",
-										"value": "consequat Ut dolore"
+										"value": "{{profileId}}"
+									},
+									{
+										"key": "Accept",
+										"value": "application/vnd.MarketingStreamSubscriptions.StreamSubscriptionResource.v1.0+json"
 									},
 									{
 										"key": "Authorization",
@@ -6075,19 +6179,13 @@
 									}
 								],
 								"url": {
-									"raw": "{{api_url}}/streams/subscriptions?maxResults=2",
+									"raw": "{{api_url}}/streams/subscriptions",
 									"host": [
 										"{{api_url}}"
 									],
 									"path": [
 										"streams",
 										"subscriptions"
-									],
-									"query": [
-										{
-											"key": "maxResults",
-											"value": "2"
-										}
 									]
 								}
 							},
@@ -6096,12 +6194,52 @@
 							"_postman_previewlanguage": "json",
 							"header": [
 								{
+									"key": "Server",
+									"value": "Server"
+								},
+								{
+									"key": "Date",
+									"value": "Wed, 01 May 2024 20:27:39 GMT"
+								},
+								{
 									"key": "Content-Type",
-									"value": "application/vnd.MarketingStreamSubscriptions.StreamSubscriptionResource.v1.0+json"
+									"value": "application/json"
+								},
+								{
+									"key": "Content-Length",
+									"value": "940"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "x-amz-rid",
+									"value": "830EGGJG4C1EQA40EY8V"
+								},
+								{
+									"key": "x-amzn-RequestId",
+									"value": "779d9da2-26d1-439c-950b-35666fcd6f21"
+								},
+								{
+									"key": "x-amz-apigw-id",
+									"value": "XG7VSGZEIAMFVIA="
+								},
+								{
+									"key": "X-Amzn-Trace-Id",
+									"value": "Root=1-6632a5bb-689c0bd5aaeb0c7f5181cd8e"
+								},
+								{
+									"key": "Vary",
+									"value": "Content-Type,Accept-Encoding,User-Agent"
+								},
+								{
+									"key": "Strict-Transport-Security",
+									"value": "max-age=47474747; includeSubDomains; preload"
 								}
 							],
 							"cookie": [],
-							"body": "{\n  \"subscriptions\": [\n    {\n      \"createdDate\": \"1954-09-09T11:09:32.877Z\",\n      \"dataSetId\": \"budget-usage\",\n      \"destinationArn\": \"etanim nisireprehenderit commodo\",\n      \"status\": \"SUSPENDED\",\n      \"subscriptionId\": \"anim reprehenderit\",\n      \"updatedDate\": \"1951-07-18T13:45:38.665Z\",\n      \"notes\": \"magna eiusmod\"\n    },\n    {\n      \"createdDate\": \"1993-05-26T17:50:38.666Z\",\n      \"dataSetId\": \"sp-conversion\",\n      \"destinationArn\": \"dolore anim nullacupidatat velit ad laboris dolor\",\n      \"status\": \"SUSPENDED\",\n      \"subscriptionId\": \"laboris non dolor sint\",\n      \"updatedDate\": \"2007-01-09T16:59:45.442Z\",\n      \"notes\": \"deserunt dolor exercitation magna\"\n    }\n  ],\n  \"nextToken\": \"xxxxxxxxxxx\"\n}"
+							"body": "{\n    \"subscriptions\": [\n        {\n            \"createdDate\": \"2024-05-01T14:43:19.136Z\",\n            \"dataSetId\": \"sp-traffic\",\n            \"destination\": {\n                \"firehoseDestination\": {\n                    \"deliveryStreamArn\": \"arn:aws:firehose:us-east-1:xxxxxxx:deliverystream/NA-sp-traffic-sp-traffic-na\",\n                    \"subscriberRoleArn\": \"arn:aws:iam::xxxxxxx:role/NA-sp-traffic-FirehoseSubscriberRole\",\n                    \"subscriptionRoleArn\": \"arn:aws:iam::xxxxxxx:role/NA-sp-traffic-FirehoseSubscriptionRole\"\n                }\n            },\n            \"notes\": \"\",\n            \"status\": \"ACTIVE\",\n            \"subscriptionId\": \"amzn1.fead.cs1.j5VQ2r3VDddWK2e_ArVApg\",\n            \"updatedDate\": \"2024-05-01T14:43:23.476Z\"\n        },\n        {\n            \"createdDate\": \"2024-05-01T14:46:26.643Z\",\n            \"dataSetId\": \"sp-traffic\",\n            \"destination\": {\n                \"sqsDestination\": {\n                    \"queueArn\": \"arn:aws:sqs:us-east-1:xxxxxx:StreamDestinationQueue\"\n                }\n            },\n            \"destinationArn\": \"arn:aws:sqs:us-east-1:xxxxxx:StreamDestinationQueue\",\n            \"notes\": \"string\",\n            \"status\": \"PENDING_CONFIRMATION\",\n            \"subscriptionId\": \"amzn1.fead.cs1.nQHVYtEaQMEqCWGBX31DHQ\",\n            \"updatedDate\": \"2024-05-01T14:46:30.02Z\"\n        }\n    ]\n}"
 						}
 					]
 				},
@@ -6167,14 +6305,16 @@
 								"method": "GET",
 								"header": [
 									{
-										"description": "(Required) The identifier of a client associated with a \"Login with Amazon\" account.",
 										"key": "Amazon-Advertising-API-ClientId",
 										"value": "{{client_id}}"
 									},
 									{
-										"description": "(Required) The identifier of a profile associated with the advertiser account. Use GET method on Profiles resource to list profiles associated with the access token passed in the HTTP Authorization header.",
 										"key": "Amazon-Advertising-API-Scope",
 										"value": "{{profileId}}"
+									},
+									{
+										"key": "Accept",
+										"value": "application/vnd.MarketingStreamSubscriptions.StreamSubscriptionResource.v1.0+json"
 									},
 									{
 										"key": "Authorization",
@@ -6195,7 +6335,7 @@
 									"variable": [
 										{
 											"key": "subscriptionId",
-											"value": "xxxxxxxxxxxx"
+											"value": "{{subscriptionId}}"
 										}
 									]
 								}
@@ -6205,12 +6345,52 @@
 							"_postman_previewlanguage": "json",
 							"header": [
 								{
+									"key": "Server",
+									"value": "Server"
+								},
+								{
+									"key": "Date",
+									"value": "Wed, 01 May 2024 21:04:57 GMT"
+								},
+								{
 									"key": "Content-Type",
-									"value": "application/vnd.MarketingStreamSubscriptions.StreamSubscriptionResource.v1.0+json"
+									"value": "application/json"
+								},
+								{
+									"key": "Content-Length",
+									"value": "578"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "x-amz-rid",
+									"value": "1P20SPM747HAZC236A1D"
+								},
+								{
+									"key": "x-amzn-RequestId",
+									"value": "98b3080d-5b70-48d8-8316-386fed2bf12a"
+								},
+								{
+									"key": "x-amz-apigw-id",
+									"value": "XHAzCG6_oAMF5RQ="
+								},
+								{
+									"key": "X-Amzn-Trace-Id",
+									"value": "Root=1-6632ae79-843db2c1b3bfe550d42d0509"
+								},
+								{
+									"key": "Vary",
+									"value": "Content-Type,Accept-Encoding,User-Agent"
+								},
+								{
+									"key": "Strict-Transport-Security",
+									"value": "max-age=47474747; includeSubDomains; preload"
 								}
 							],
 							"cookie": [],
-							"body": "{\n  \"subscription\": {\n    \"createdDate\": \"1995-12-19T01:37:51.432Z\",\n    \"dataSetId\": \"sp-conversion\",\n    \"destinationArn\": \"xxxxxxxxxxxxx\",\n    \"status\": \"PENDING_CONFIRMATION\",\n    \"subscriptionId\": \"xxxxxxxxxxxxxx\",\n    \"updatedDate\": \"2015-02-05T11:12:31.839Z\",\n    \"notes\": \"sp-conversion subscription\"\n  }\n}"
+							"body": "{\n    \"subscription\": {\n        \"createdDate\": \"2024-05-01T21:03:47.714Z\",\n        \"dataSetId\": \"sp-conversion\",\n        \"destination\": {\n            \"firehoseDestination\": {\n                \"deliveryStreamArn\": \"arn:aws:firehose:us-east-1:xxxxxxxx:deliverystream/NA-sp-conversion-StreamDestinationFirehoseSpConversionNA\",\n                \"subscriberRoleArn\": \"arn:aws:iam::xxxxxxxx:role/NA-sp-conversion-FirehoseSubscriberRole\",\n                \"subscriptionRoleArn\": \"arn:aws:iam::xxxxxx:role/NA-sp-conversion-FirehoseSubscriptionRole\"\n            }\n        },\n        \"notes\": \"\",\n        \"status\": \"ACTIVE\",\n        \"subscriptionId\": \"amzn1.fead.cs1.kDOCOan12sYjMoSFVNZLHg\",\n        \"updatedDate\": \"2024-05-01T21:03:50.027Z\"\n    }\n}"
 						}
 					]
 				},

--- a/postman/README.md
+++ b/postman/README.md
@@ -14,13 +14,14 @@ The Amazon Ads API Postman collection currently supports the following features:
 - GET profiles
 - GET manager accounts
 - Sponsored Products campaign management (version 3)
+- Sponsored Brands campaign management (version 4)
 - Sponsored ads reporting
     - Version 3
     - Version 2
 - DSP reporting
 - Sponsored ads snapshots 
 - Test accounts
-- Amazon Marketing Stream beta
+- Amazon Marketing Stream
 - Product metadata 
 - Sponsored ads budget usage
 - Sponsored ads budget rules
@@ -29,6 +30,7 @@ The Amazon Ads API Postman collection currently supports the following features:
 - Stores
 - Locations
 - Sponsored Display
+- Sponsored TV
 - Exports
 
 ## Setup


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds CloudFormation templates to support Firehose streams and CloudWatch dashboards.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
