### PR TITLE
add Amazon Marketing Cloud folder

### DIFF
--- a/postman/Amazon_Ads_API.postman_collection.json
+++ b/postman/Amazon_Ads_API.postman_collection.json
@@ -6242,6 +6242,4281 @@
 			"description": "Full API reference available in the [advanced tools center](https://advertising.amazon.com/API/docs/en-us/amazon-marketing-stream/openapi)."
 		},
 		{
+			"name": "Amazon Marketing Cloud",
+			"item": [
+				{
+					"name": "Administration",
+					"item": [
+						{
+							"name": "Accounts",
+							"item": [
+								{
+									"name": "List all AMC accounts",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"// Stores the accountId and marketplaceId in environment variables\r",
+													"var responseBody = pm.response.json();\r",
+													"var amcAccount = responseBody.amcAccounts[0];\r",
+													"pm.environment.set(\"advertiser_id\", amcAccount.accountId);\r",
+													"pm.environment.set(\"marketplace_id\", amcAccount.marketplaceId);"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) The identifier of a client associated with an Amazon Developer account.",
+												"type": "default"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "default"
+											}
+										],
+										"url": "{{api_url}}/amc/accounts",
+										"description": "The `GET` request to `/amc/accounts` endpoint retrieves a list of AMC (Asset Management Company) accounts. The response is in JSON format and has a schema as follows:\n\n``` json\n{\n  \"type\": \"object\",\n  \"properties\": {\n    \"amcAccounts\": {\n      \"type\": \"array\",\n      \"items\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"accountId\": {\n            \"type\": \"string\"\n          },\n          \"accountName\": {\n            \"type\": \"string\"\n          },\n          \"marketplaceId\": {\n            \"type\": \"string\"\n          }\n        }\n      }\n    }\n  }\n}\n}\n\n ```"
+									},
+									"response": [
+										{
+											"name": "List all AMC accounts",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"type": "default"
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "default"
+													}
+												],
+												"url": "{{api_url}}/amc/accounts"
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Wed, 25 Sep 2024 03:50:43 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json",
+													"description": "",
+													"type": "text"
+												},
+												{
+													"key": "Content-Length",
+													"value": "740"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "98PSM5K8Q7M49AZ9WKY4"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "98PSM5K8Q7M49AZ9WKY4"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"amcAccounts\": [\n        {\n            \"accountId\": \"ENTITY1AA1AA11AAA1\",\n            \"accountName\": \"AMC Test Account\",\n            \"marketplaceId\": \"ATVPDKIKX0DER\"\n        },\n        {\n            \"accountId\": \"ENTITY1AA1AA11AAA2\",\n            \"accountName\": \"AMC Sandbox Test Account\",\n            \"marketplaceId\": \"ATVPDKIKX0DER\"\n        },\n        {\n            \"accountId\": \"ENTITY1AA1AA11AAA3\",\n            \"accountName\": \"AMC Demo Account\",\n            \"marketplaceId\": \"ATVPDKIKX0DER\"\n        } \n    ]\n}"
+										}
+									]
+								}
+							],
+							"description": "The AMC account refers to the account identifier or entity identifier associated with the email address that you used to sign up on the Amazon Ads console. This identifier is similar to an Amazon DSP entity or sponsored ads entities. With an AMC account, advertisers will be able to include multiple AMC instances in a single place. An example of an AMC account identifier (entity identifier) is: `ENTITY1AA1AA11AAA1`.\n\nFor more information, see [Account management](https://advertising.amazon.com/API/docs/en-us/guides/amazon-marketing-cloud/admin/account-management)."
+						},
+						{
+							"name": "Instances",
+							"item": [
+								{
+									"name": "Create an instance",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"var responseBody = pm.response.json();\r",
+													"var instanceId = responseBody.instance.instanceId;\r",
+													"pm.environment.set(\"instanceId\", instanceId);\r",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n   \"instanceName\": \"myfirstinstance\"\n}"
+										},
+										"url": "{{api_url}}/amc/instances"
+									},
+									"response": [
+										{
+											"name": "Create an instance",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													},
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"type": "text"
+													},
+													{
+														"key": "Amazon-Ads-AccountId",
+														"value": "{{amc_account_id}}",
+														"type": "text"
+													},
+													{
+														"key": "Amazon-Advertising-API-MarketplaceId",
+														"value": "{{marketplace_id}}",
+														"type": "text"
+													},
+													{
+														"key": "Amazon-Advertising-API-AdvertiserId",
+														"value": "{{amc_account_id}}",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"instanceName\": \"myinstance\"\n}"
+												},
+												"url": "{{api_url}}/amc/instances"
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Fri, 13 Sep 2024 04:07:53 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json",
+													"description": "",
+													"type": "text"
+												},
+												{
+													"key": "Content-Length",
+													"value": "369"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "9HSAPY8KZY18YHC0CDWA"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "9HSAPY8KZY18YHC0CDWA"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"instance\": {\n        \"instanceId\": \"amcr1aaaa1a\",\n        \"instanceName\": \"myinstance\",\n        \"instanceType\": \"STANDARD\",\n        \"customerCanonicalName\": null,\n        \"creationStatus\": \"REQUESTED\",\n        \"creationDatetime\": null,\n        \"s3BucketName\": \"\",\n        \"awsAccountId\": \"682015406404\",\n        \"entities\": [\n            \"NA\"\n        ],\n        \"dataUploadAwsAccountId\": \"811639200769\",\n        \"apiEndpoint\": null,\n        \"acrCollaboration\": null,\n        \"optionalDatasets\": [],\n        \"advertiserTypes\": []\n    }\n}"
+										},
+										{
+											"name": "Create a collaboration instance",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"type": "text"
+													},
+													{
+														"key": "Amazon-Advertising-API-MarketplaceId",
+														"value": "{{marketplace_id}}",
+														"type": "text"
+													},
+													{
+														"key": "Amazon-Advertising-API-AdvertiserId",
+														"value": "{{advertiser_id}}",
+														"type": "text"
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n   \"instanceName\": \"myacrinstance\",\n   \"advertiserName\": \"Advertiser A\",\n   \"awsAccountId\": \"131469670754\",\n   \"acrBacked\": \"true\"\n}"
+												},
+												"url": "{{api_url}}/amc/instances"
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Fri, 06 Dec 2024 02:46:01 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json",
+													"name": "Content-Type",
+													"description": "",
+													"type": "text"
+												},
+												{
+													"key": "Content-Length",
+													"value": "482"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "FQKFQZTR1NK3DSVHG650"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "FQKFQZTR1NK3DSVHG650"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"instance\": {\n        \"instanceId\": \"amcr1aaaa1a\",\n        \"instanceName\": \"myacrinstance\",\n        \"instanceType\": \"STANDARD\",\n        \"customerCanonicalName\": \"Advertiser A\",\n        \"creationStatus\": \"REQUESTED\",\n        \"creationDatetime\": null,\n        \"s3BucketName\": \"\",\n        \"awsAccountId\": \"111111111111\",\n        \"entities\": [\n            \"NA\"\n        ],\n        \"dataUploadAwsAccountId\": \"811639200769\",\n        \"apiEndpoint\": null,\n        \"acrCollaboration\": {\n            \"id\": \"\",\n            \"name\": \"AMC amcr1aaaa1a\",\n            \"description\": \"AMC Clean Room collaboration for instance amcr1aaaa1a\"\n        },\n        \"optionalDatasets\": [],\n        \"advertiserTypes\": []\n    }\n}"
+										}
+									]
+								},
+								{
+									"name": "List all instances",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/amc/instances?nextToken=",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"amc",
+												"instances"
+											],
+											"query": [
+												{
+													"key": "nextToken",
+													"value": "",
+													"description": "Optional. Token to retrieve subsequent page of results."
+												},
+												{
+													"key": "limit",
+													"value": "<string>",
+													"description": "Optional. Limits the number of items to return in the response. Max value is 100. Defaults to 100.",
+													"disabled": true
+												}
+											]
+										},
+										"description": "Gets information about all AMC instances that the requesting entity has access to. Information for each instance includes the name, creation status, and the entities with access to the instance."
+									},
+									"response": [
+										{
+											"name": "Gets information about all AMC instances",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+													},
+													{
+														"key": "Amazon-Advertising-API-Scope",
+														"value": "<string>",
+														"description": "This header is deprecated.   Clients must pass in Amazon-Advertising-API-AdvertiserId and Amazon-Advertising-API-MarketplaceId as headers",
+														"disabled": true
+													},
+													{
+														"key": "Amazon-Advertising-API-AdvertiserId",
+														"value": "{{advertiser_id}}",
+														"description": "(Required) Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+													},
+													{
+														"key": "Amazon-Advertising-API-MarketplaceId",
+														"value": "{{marketplace_id}}",
+														"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{api_url}}/amc/instances?nextToken=",
+													"host": [
+														"{{api_url}}"
+													],
+													"path": [
+														"amc",
+														"instances"
+													],
+													"query": [
+														{
+															"key": "nextToken",
+															"value": "",
+															"description": "Optional. Token to retrieve subsequent page of results."
+														},
+														{
+															"key": "limit",
+															"value": "<string>",
+															"description": "Optional. Limits the number of items to return in the response. Max value is 100. Defaults to 100.",
+															"disabled": true
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Thu, 19 Sep 2024 16:18:10 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json",
+													"description": "",
+													"type": "text"
+												},
+												{
+													"key": "Transfer-Encoding",
+													"value": "chunked"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "TPF4PT86ZVHPMRH71M42"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "TPF4PT86ZVHPMRH71M42"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"instances\": [\n        {\n            \"instanceId\": \"amcr1aaaa1a\",\n            \"instanceName\": \"myinstance\",\n            \"instanceType\": \"STANDARD\",\n            \"customerCanonicalName\": \"Sample Instance\",\n            \"creationStatus\": \"COMPLETED\",\n            \"creationDatetime\": \"2024-03-29T08:12:11.572511Z\",\n            \"s3BucketName\": \"amc-sample-instance-bucket\",\n            \"awsAccountId\": \"\",\n            \"entities\": [\n                \"NA\"\n            ],\n            \"dataUploadAwsAccountId\": \"811639200769\",\n            \"apiEndpoint\": \"https://advertising-api.amazon.com\",\n            \"acrCollaboration\": null,\n            \"optionalDatasets\": [\n                {\n                    \"label\": \"CASPIAN_DIM_CUTOVER\",\n                    \"activationTime\": \"2024-03-27T12:07:25.614Z\"\n                },\n                {\n                    \"label\": \"CASPIAN_DIM_CUTOVER_CONVERSIONS\",\n                    \"activationTime\": \"2024-03-27T12:07:25.614Z\"\n                },\n                {\n                    \"label\": \"CASPIAN_FACT_CUTOVER\",\n                    \"activationTime\": \"2024-03-27T12:07:25.614Z\"\n                },\n                {\n                    \"label\": \"CASPIAN_ONLY\",\n                    \"activationTime\": \"2024-03-27T12:07:25.614Z\"\n                },\n                {\n                    \"label\": \"CONVERSIONS_EXPOSURE_V3\",\n                    \"activationTime\": \"2024-06-27T13:51:29.259Z\"\n                }\n            ],\n            \"advertiserTypes\": [\n                \"DISPLAY\",\n                \"SPONSORED_ADS\"\n            ]\n        }\n    ],\n    \"nextToken\": null\n}"
+										}
+									]
+								},
+								{
+									"name": "List information about the requested instance",
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"description": "(Required) Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"url": "{{api_url}}/amc/instances/{{instanceId}}",
+										"description": "Gets information about the requested AMC instance. Information includes the name, creation status, and the entities with access to the instance."
+									},
+									"response": [
+										{
+											"name": "Gets information about the requested AMC instance.",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+													},
+													{
+														"key": "Amazon-Advertising-API-Scope",
+														"value": "",
+														"description": "This header is deprecated.   Clients must pass in Amazon-Advertising-API-AdvertiserId and Amazon-Advertising-API-MarketplaceId as headers",
+														"disabled": true
+													},
+													{
+														"key": "Amazon-Advertising-API-AdvertiserId",
+														"value": "{{advertiser_id}}",
+														"description": "(Required) Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+													},
+													{
+														"key": "Amazon-Advertising-API-MarketplaceId",
+														"value": "{{marketplace_id}}",
+														"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+													},
+													{
+														"key": "Accept",
+														"value": "application/vnd.amcinstances.v1+json",
+														"disabled": true
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{api_url}}/amc/instances/:instanceId",
+													"host": [
+														"{{api_url}}"
+													],
+													"path": [
+														"amc",
+														"instances",
+														":instanceId"
+													],
+													"variable": [
+														{
+															"key": "instanceId",
+															"value": "{{instanceId}}"
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Thu, 19 Sep 2024 17:24:27 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json",
+													"description": "",
+													"type": "text"
+												},
+												{
+													"key": "Content-Length",
+													"value": "906"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "9TTW7X88G8856A6R3K4X"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "9TTW7X88G8856A6R3K4X"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"instance\": {\n        \"instanceId\": \"amcr1aaaa1a\",\n        \"instanceName\": \"myinstance\",\n        \"instanceType\": \"STANDARD\",\n        \"customerCanonicalName\": \"Sample Instance\",\n        \"creationStatus\": \"COMPLETED\",\n        \"creationDatetime\": \"2024-03-29T08:12:11.572511Z\",\n        \"s3BucketName\": \"amc-sample-instance-bucket\",\n        \"awsAccountId\": \"\",\n        \"entities\": [\n            \"NA\"\n        ],\n        \"dataUploadAwsAccountId\": \"811639200769\",\n        \"apiEndpoint\": \"https://advertising-api.amazon.com\",\n        \"acrCollaboration\": null,\n        \"optionalDatasets\": [\n            {\n                \"label\": \"CASPIAN_DIM_CUTOVER\",\n                \"activationTime\": \"2024-03-27T12:07:25.614Z\"\n            },\n            {\n                \"label\": \"CASPIAN_DIM_CUTOVER_CONVERSIONS\",\n                \"activationTime\": \"2024-03-27T12:07:25.614Z\"\n            },\n            {\n                \"label\": \"CASPIAN_FACT_CUTOVER\",\n                \"activationTime\": \"2024-03-27T12:07:25.614Z\"\n            },\n            {\n                \"label\": \"CASPIAN_ONLY\",\n                \"activationTime\": \"2024-03-27T12:07:25.614Z\"\n            },\n            {\n                \"label\": \"CONVERSIONS_EXPOSURE_V3\",\n                \"activationTime\": \"2024-06-27T13:51:29.259Z\"\n            }\n        ],\n        \"advertiserTypes\": [\n            \"DISPLAY\",\n            \"SPONSORED_ADS\"\n        ]\n    }\n}"
+										}
+									]
+								},
+								{
+									"name": "Update instance details",
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"instanceName\":\"myinstance\",\n    \"advertiserName\":\"Advertiser B\"\n}"
+										},
+										"url": "{{api_url}}/amc/instances/{{instanceId}}"
+									},
+									"response": [
+										{
+											"name": "Update AMC instance",
+											"originalRequest": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"type": "text"
+													},
+													{
+														"key": "Amazon-Advertising-API-MarketplaceId",
+														"value": "{{marketplace_id}}",
+														"type": "text"
+													},
+													{
+														"key": "Amazon-Advertising-API-AdvertiserId",
+														"value": "{{advertiser_id}}",
+														"type": "text"
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"instanceName\":\"myinstance\",\n    \"advertiserName\":\"Advertiser B\"\n}"
+												},
+												"url": "{{api_url}}/amc/instances/{{instanceId}}"
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Thu, 21 Nov 2024 04:43:38 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json",
+													"description": "",
+													"type": "text"
+												},
+												{
+													"key": "Content-Length",
+													"value": "808"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "N0QADTNK2FBBW1G2VWWP"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "N0QADTNK2FBBW1G2VWWP"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"instance\": {\n        \"instanceId\": \"amcr1aaaa1a\",\n        \"instanceName\": \"myinstance\",\n        \"instanceType\": \"STANDARD\",\n        \"customerCanonicalName\": \"Advertiser B\",\n        \"creationStatus\": \"COMPLETED\",\n        \"creationDatetime\": \"2024-11-20T21:31:46.455292153Z\",\n        \"s3BucketName\": \"my-S3-Bucket\",\n        \"awsAccountId\": \"682015406404\",\n        \"entities\": [\n            \"NA\"\n        ],\n        \"dataUploadAwsAccountId\": \"811639200769\",\n        \"apiEndpoint\": null,\n        \"acrCollaboration\": null,\n        \"optionalDatasets\": [\n            {\n                \"label\": \"CASPIAN_DIM_CUTOVER\",\n                \"activationTime\": \"2024-11-20T21:30:12.912Z\"\n            },\n            {\n                \"label\": \"CASPIAN_DIM_CUTOVER_CONVERSIONS\",\n                \"activationTime\": \"2024-11-20T21:30:12.912Z\"\n            },\n            {\n                \"label\": \"CASPIAN_FACT_CUTOVER\",\n                \"activationTime\": \"2024-11-20T21:30:12.912Z\"\n            },\n            {\n                \"label\": \"CASPIAN_ONLY\",\n                \"activationTime\": \"2024-11-20T21:30:12.912Z\"\n            },\n            {\n                \"label\": \"CONVERSIONS_EXPOSURE_V3\",\n                \"activationTime\": \"2024-11-20T21:30:12.912Z\"\n            }\n        ],\n        \"advertiserTypes\": []\n    }\n}"
+										}
+									]
+								},
+								{
+									"name": "Update AWS account metadata in the requested instance",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"description": "(Required) Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"awsAccountId\": \"131469670754\",\n  \"bucketName\": \"The-big--bucket\"\n}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": "{{api_url}}/amc/instances/{{instanceId}}/updateCustomerAwsAccount",
+										"description": "**Note**: Adminstrative permissions required.  \nAccepts the AWS Account ID and the S3 bucket name as the request body’s payload and returns a CloudFormation link that you can use to update the S3 bucket."
+									},
+									"response": [
+										{
+											"name": "Update AWS account metadata in the requested AMC instance.",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+													},
+													{
+														"key": "Amazon-Advertising-API-MarketplaceId",
+														"value": "{{marketplace_id}}",
+														"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+													},
+													{
+														"key": "Amazon-Advertising-API-AdvertiserId",
+														"value": "{{advertiser_id}}",
+														"description": "(Required) Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"awsAccountId\": \"131469670754\",\n  \"bucketName\": \"The-big-bucket\"\n}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": "{{api_url}}/amc/instances/{{instanceId}}/updateCustomerAwsAccount"
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "raw",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Thu, 03 Oct 2024 02:19:30 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/octet-stream"
+												},
+												{
+													"key": "Content-Length",
+													"value": "308"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "BNP0ZD6WJMCJJ0SW2BDA"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "BNP0ZD6WJMCJJ0SW2BDA"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\"cfnBucketUrl\":\"https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://public-file-hosting-repository.s3.amazonaws.com/cfn-template.yaml&stackName=amcDeliveryBucketStack&param_pBucketName=The-big-bucket&param_pCrossAccountAccessAccountId=811639200769\"}"
+										}
+									]
+								},
+								{
+									"name": "List advertisers in instance",
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "default"
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"type": "default"
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"type": "default"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "default"
+											}
+										],
+										"url": "{{api_url}}/amc/instances/{{instanceId}}/advertisers"
+									},
+									"response": [
+										{
+											"name": "List instance advertisers",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"type": "default"
+													},
+													{
+														"key": "Amazon-Advertising-API-AdvertiserId",
+														"value": "{{advertiser_id}}",
+														"type": "default"
+													},
+													{
+														"key": "Amazon-Advertising-API-MarketplaceId",
+														"value": "{{marketplace_id}}",
+														"type": "default"
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "default"
+													}
+												],
+												"url": "{{api_url}}/amc/instances/{{instanceId}}/advertisers"
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Thu, 21 Nov 2024 04:45:05 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json",
+													"description": "",
+													"type": "text"
+												},
+												{
+													"key": "Content-Length",
+													"value": "50"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "07AKD7Q5M2KGF6YV59VW"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "07AKD7Q5M2KGF6YV59VW"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"advertisers\": [],\n    \"nextToken\": null,\n    \"totalCount\": 0\n}"
+										}
+									]
+								},
+								{
+									"name": "Create advertiser update",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "default"
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"type": "default"
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"type": "default"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "default"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"advertisersToAdd\": [\n      {\n        \"id\": \"ENTITY3E2E9XK5B617C\",\n        \"type\":\"SPONSORED_ADS\",\n        \"marketplaceId\":\"ATVPDKIKX0DER\"\n      }\n  ],\n  \"advertisersToRemove\": [\n  ]\n}"
+										},
+										"url": "{{api_url}}/amc/instances/{{instanceId}}/advertisers/updates"
+									},
+									"response": [
+										{
+											"name": "Create advertiser update",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"type": "default"
+													},
+													{
+														"key": "Amazon-Advertising-API-MarketplaceId",
+														"value": "{{marketplace_id}}",
+														"type": "default"
+													},
+													{
+														"key": "Amazon-Advertising-API-AdvertiserId",
+														"value": "{{advertiser_id}}",
+														"type": "default"
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "default"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"advertisersToAdd\": [\n      {\n        \"id\": \"ENTITY3E2E9XK5B617C\",\n        \"type\":\"SPONSORED_ADS\",\n        \"marketplaceId\":\"ATVPDKIKX0DER\"\n      }\n  ],\n  \"advertisersToRemove\": [\n  ]\n}"
+												},
+												"url": "{{api_url}}/amc/instances/{{instanceId}}/advertisers/updates"
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Thu, 21 Nov 2024 04:45:43 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json",
+													"description": "",
+													"type": "text"
+												},
+												{
+													"key": "Content-Length",
+													"value": "184"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "J66PY9AV7WD3X0GTDZC7"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "J66PY9AV7WD3X0GTDZC7"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"advertiserUpdate\": {\n        \"updateId\": 0,\n        \"status\": \"PENDING\",\n        \"advertisersToAdd\": [\n            {\n                \"id\": \"ENTITY1AA1AA11AAA1\",\n                \"marketplaceId\": \"ATVPDKIKX0DER\",\n                \"type\": \"SPONSORED_ADS\"\n            }\n        ],\n        \"advertisersToRemove\": []\n    }\n}"
+										}
+									]
+								},
+								{
+									"name": "Get advertiser update",
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"url": "{{api_url}}/amc/instances/{{instanceId}}/advertisers/updates/"
+									},
+									"response": [
+										{
+											"name": "Get advertiser update",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													},
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"type": "text"
+													},
+													{
+														"key": "Amazon-Ads-AccountId",
+														"value": "{{amc_account_id}}",
+														"description": "Does not work",
+														"type": "text",
+														"disabled": true
+													},
+													{
+														"key": "Amazon-Advertising-API-MarketplaceId",
+														"value": "ATVPDKIKX0DER",
+														"type": "text"
+													},
+													{
+														"key": "Amazon-Advertising-API-AdvertiserId",
+														"value": "{{amc_account_id}}",
+														"type": "text"
+													}
+												],
+												"url": "{{api_url}}/amc/instances/{{instanceId}}/advertisers/updates/0"
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Thu, 12 Sep 2024 18:27:59 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json",
+													"description": "",
+													"type": "text"
+												},
+												{
+													"key": "Content-Length",
+													"value": "102"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "DTRDRDM4DJTBRE7XAV5H"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "DTRDRDM4DJTBRE7XAV5H"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"advertiserUpdate\": {\n        \"updateId\": 0,\n        \"status\": \"COMPLETE\",\n        \"advertisersToAdd\": [],\n        \"advertisersToRemove\": []\n    }\n}"
+										}
+									]
+								},
+								{
+									"name": "Gets advertiser information about the requested AMC instance",
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"description": "(Required) Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/amc/instances/{{instanceId}}/advertisers",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"amc",
+												"instances",
+												"{{instanceId}}",
+												"advertisers"
+											],
+											"query": [
+												{
+													"key": "type",
+													"value": "<string>",
+													"description": "Optional. Filter advertisers by advertiser type in the response, if not provided, return all advertisers",
+													"disabled": true
+												},
+												{
+													"key": "nextToken",
+													"value": "<string>",
+													"description": "Optional. Token to retrieve subsequent page of results.",
+													"disabled": true
+												},
+												{
+													"key": "limit",
+													"value": "100",
+													"description": "Optional. Limits the number of items to return in the response. Max value is 100. Defaults to 100.",
+													"disabled": true
+												}
+											]
+										},
+										"description": "Gets advertisers information about the requested AMC instance."
+									},
+									"response": [
+										{
+											"name": "Gets advertiser information about the requested AMC instance.",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+													},
+													{
+														"key": "Amazon-Advertising-API-Scope",
+														"value": "<string>",
+														"description": "This header is deprecated.   Clients must pass in Amazon-Advertising-API-AdvertiserId and Amazon-Advertising-API-MarketplaceId as headers",
+														"disabled": true
+													},
+													{
+														"key": "Amazon-Advertising-API-AdvertiserId",
+														"value": "{{advertiser_id}}",
+														"description": "(Required) Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+													},
+													{
+														"key": "Amazon-Advertising-API-MarketplaceId",
+														"value": "{{marketplace_id}}",
+														"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+													},
+													{
+														"key": "Accept",
+														"value": "application/vnd.amcinstances.v1+json",
+														"disabled": true
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{api_url}}/amc/instances/:instanceId/advertisers",
+													"host": [
+														"{{api_url}}"
+													],
+													"path": [
+														"amc",
+														"instances",
+														":instanceId",
+														"advertisers"
+													],
+													"query": [
+														{
+															"key": "type",
+															"value": "<string>",
+															"description": "Optional. Filter advertisers by advertiser type in the response, if not provided, return all advertisers",
+															"disabled": true
+														},
+														{
+															"key": "nextToken",
+															"value": "<string>",
+															"description": "Optional. Token to retrieve subsequent page of results.",
+															"disabled": true
+														},
+														{
+															"key": "limit",
+															"value": "100",
+															"description": "Optional. Limits the number of items to return in the response. Max value is 100. Defaults to 100.",
+															"disabled": true
+														}
+													],
+													"variable": [
+														{
+															"key": "instanceId",
+															"value": "{{instanceId}}"
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Thu, 19 Sep 2024 17:26:24 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json",
+													"description": "",
+													"type": "text"
+												},
+												{
+													"key": "Content-Length",
+													"value": "497"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "JNADM02E6HDQFT1TAPWY"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "JNADM02E6HDQFT1TAPWY"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"advertisers\": [\n        {\n            \"name\": \"KitchenSmart\",\n            \"id\": \"7909698120101\",\n            \"marketplaceId\": null,\n            \"type\": \"DISPLAY\",\n            \"configuredAdvertiserTypes\": [\n                \"DISPLAY\"\n            ]\n        },\n        ],\n    \"nextToken\": null,\n    \"totalCount\": 1\n}"
+										}
+									]
+								},
+								{
+									"name": "Delete AMC instance",
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"type": "text"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"url": "{{api_url}}/amc/instances/{{instanceId}}"
+									},
+									"response": []
+								}
+							],
+							"description": "An instance is the actual AMC \"clean room\" that is set up for a given advertiser or company. This means each instance contains records from only a single advertiser. Within the Amazon DSP an advertiser may be represented by one or more \"advertiser IDs\" or multiple \"entity IDs\" within the advertising console for sponsored ads."
+						}
+					],
+					"description": "This set of APIs allow developers to manage their Amazon Marketing Cloud accounts and instances.\n\nFor details, see [AMC administration overview.](https://advertising.amazon.com/API/docs/en-us/guides/amazon-marketing-cloud/admin/1_amc_administration)"
+				},
+				{
+					"name": "Reporting",
+					"item": [
+						{
+							"name": "Workflows",
+							"item": [
+								{
+									"name": "Create a workflow",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"workflowId\": \"my-first-workflow0001\",\n    \"sqlQuery\": \"SELECT advertiser, campaign, sum(total_cost) as spend, sum(impressions) as impressions, count(DISTINCT user_id) as reach FROM dsp_impressions GROUP BY advertiser, campaign\"\n},\n    \"timeWindowTimeZone\": \"UTC\",\n    \"timeWindowType\": \"MOST_RECENT_WEEK\"\n}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": "{{api_url}}/amc/reporting/{{instanceId}}/workflows",
+										"description": "Creates a new workflow. The request body is used as the definition for the new workflow. Workflows are defined as a set of operations that take previously defined data sources as input and use them to generate reports."
+									},
+									"response": [
+										{
+											"name": "Create a workflow",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+													},
+													{
+														"key": "Amazon-Advertising-API-Scope",
+														"value": "",
+														"description": "This header is deprecated.   Clients must pass in Amazon-Advertising-API-AdvertiserId and Amazon-Advertising-API-MarketplaceId as headers",
+														"disabled": true
+													},
+													{
+														"key": "Amazon-Advertising-API-AdvertiserId",
+														"value": "{{advertiser_id}}",
+														"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+													},
+													{
+														"key": "Amazon-Advertising-API-MarketplaceId",
+														"value": "{{marketplace_id}}",
+														"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.amcworkflows.v1+json",
+														"disabled": true
+													},
+													{
+														"key": "Accept",
+														"value": "application/vnd.amcworkflows.v1+json",
+														"disabled": true
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"workflowId\": \"my-first-workflow-of-the-day\",\n    \"sqlQuery\": \"SELECT advertiser, campaign, sum(total_cost) as spend, sum(impressions) as impressions, count(DISTINCT user_id) as reach FROM dsp_impressions GROUP BY advertiser, campaign\"\n},\n    \"timeWindowTimeZone\": \"UTC\",\n    \"timeWindowType\": \"MOST_RECENT_WEEK\"\n}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{api_url}}/amc/reporting/:instanceId/workflows",
+													"host": [
+														"{{api_url}}"
+													],
+													"path": [
+														"amc",
+														"reporting",
+														":instanceId",
+														"workflows"
+													],
+													"variable": [
+														{
+															"key": "instanceId",
+															"value": "{{instanceId}}",
+															"description": "(Required)  The AMC instance identifier required for operations that read or write to a specific AMC instance. This can be retrieved by making a GET request to /amc/instances endpoint or from the AMC UI through the Instance info page."
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "raw",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Thu, 19 Sep 2024 16:04:00 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/octet-stream"
+												},
+												{
+													"key": "Content-Length",
+													"value": "2"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "EE0DHK9BNHGFRCGB95N5"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "EE0DHK9BNHGFRCGB95N5"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{}"
+										}
+									]
+								},
+								{
+									"name": "Create a workflow with custom parameters",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"workflowId\": \"my-first-workflow-with-custom-parameters\",\n    \"sqlQuery\": \"SELECT campaign, SUM(IMPRESSIONS) AS Impressions FROM sponsored_ads_traffic WHERE ARRAY_CONTAINS(CUSTOM_PARAMETER('sa_campaigns'), 'ALL') OR ARRAY_CONTAINS(CUSTOM_PARAMETER('sa_campaigns'), campaign) GROUP BY 1\",\n    \"inputParameters\": [\n        {\n            \"name\": \"sa_campaigns\",\n            \"dataType\": {\n                \"elementDataType\": \"STRING\",\n                \"type\": \"ARRAY\"\n                },\n            \"column_type\": \"DIMENSION\",\n            \"description\": \"Enter description for parameter\",\n            \"defaultValue\": [\n                \"ALL\"\n                ]\n        }\n    ]\n}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{api_url}}/amc/reporting/:instanceId/workflows",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"amc",
+												"reporting",
+												":instanceId",
+												"workflows"
+											],
+											"variable": [
+												{
+													"key": "instanceId",
+													"value": "{{instanceId}}",
+													"description": "(Required)  The AMC instance identifier required for operations that read or write to a specific AMC instance. This can be retrieved by making a GET request to /amc/instances endpoint or from the AMC UI through the Instance info page."
+												}
+											]
+										},
+										"description": "Creates a new workflow. The request body is used as the definition for the new workflow. Workflows are defined as a set of operations that take previously defined data sources as input and use them to generate reports."
+									},
+									"response": [
+										{
+											"name": "Create a new workflow",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+													},
+													{
+														"key": "Amazon-Advertising-API-Scope",
+														"value": "",
+														"description": "This header is deprecated.   Clients must pass in Amazon-Advertising-API-AdvertiserId and Amazon-Advertising-API-MarketplaceId as headers",
+														"disabled": true
+													},
+													{
+														"key": "Amazon-Advertising-API-AdvertiserId",
+														"value": "{{advertiser_id}}",
+														"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+													},
+													{
+														"key": "Amazon-Advertising-API-MarketplaceId",
+														"value": "{{marketplace_id}}",
+														"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.amcworkflows.v1+json",
+														"disabled": true
+													},
+													{
+														"key": "Accept",
+														"value": "application/vnd.amcworkflows.v1+json",
+														"disabled": true
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"workflowId\": \"my-first-workflow\",\n    \"sqlQuery\": \"SELECT campaign_id,SUM(impressions) AS impressions FROM dsp_impressions GROUP by campaign_id\"\n},\n    \"timeWindowTimeZone\": \"UTC\",\n    \"timeWindowType\": \"MOST_RECENT_WEEK\"\n}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{api_url}}/amc/reporting/:instanceId/workflows",
+													"host": [
+														"{{api_url}}"
+													],
+													"path": [
+														"amc",
+														"reporting",
+														":instanceId",
+														"workflows"
+													],
+													"variable": [
+														{
+															"key": "instanceId",
+															"value": "{{instanceId}}",
+															"description": "(Required)  The AMC instance identifier required for operations that read or write to a specific AMC instance. This can be retrieved by making a GET request to /amc/instances endpoint or from the AMC UI through the Instance info page."
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "raw",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Thu, 19 Sep 2024 16:04:00 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/octet-stream"
+												},
+												{
+													"key": "Content-Length",
+													"value": "2"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "EE0DHK9BNHGFRCGB95N5"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "EE0DHK9BNHGFRCGB95N5"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{}"
+										},
+										{
+											"name": "Create a workflow with custom parameters",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+													},
+													{
+														"key": "Amazon-Advertising-API-Scope",
+														"value": "",
+														"description": "This header is deprecated.   Clients must pass in Amazon-Advertising-API-AdvertiserId and Amazon-Advertising-API-MarketplaceId as headers",
+														"disabled": true
+													},
+													{
+														"key": "Amazon-Advertising-API-AdvertiserId",
+														"value": "{{advertiser_id}}",
+														"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+													},
+													{
+														"key": "Amazon-Advertising-API-MarketplaceId",
+														"value": "{{marketplace_id}}",
+														"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.amcworkflows.v1+json",
+														"disabled": true
+													},
+													{
+														"key": "Accept",
+														"value": "application/vnd.amcworkflows.v1+json",
+														"disabled": true
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"workflowId\": \"my-first-workflow-with-custom-parameters\",\n    \"sqlQuery\": \"SELECT campaign, SUM(IMPRESSIONS) AS Impressions FROM sponsored_ads_traffic WHERE ARRAY_CONTAINS(CUSTOM_PARAMETER('sa_campaigns'), 'ALL') OR ARRAY_CONTAINS(CUSTOM_PARAMETER('sa_campaigns'), campaign) GROUP BY 1\",\n    \"inputParameters\": [\n        {\n            \"name\": \"sa_campaigns\",\n            \"dataType\": {\n                \"elementDataType\": \"STRING\",\n                \"type\": \"ARRAY\"\n                },\n            \"column_type\": \"DIMENSION\",\n            \"description\": \"Enter description for parameter\",\n            \"defaultValue\": [\n                \"ALL\"\n                ]\n        }\n    ]\n}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{api_url}}/amc/reporting/:instanceId/workflows",
+													"host": [
+														"{{api_url}}"
+													],
+													"path": [
+														"amc",
+														"reporting",
+														":instanceId",
+														"workflows"
+													],
+													"variable": [
+														{
+															"key": "instanceId",
+															"value": "{{instanceId}}",
+															"description": "(Required)  The AMC instance identifier required for operations that read or write to a specific AMC instance. This can be retrieved by making a GET request to /amc/instances endpoint or from the AMC UI through the Instance info page."
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "raw",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Wed, 25 Sep 2024 02:12:18 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/octet-stream"
+												},
+												{
+													"key": "Content-Length",
+													"value": "2"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "VDECQ2SHPANHMF9FH8Y3"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "VDECQ2SHPANHMF9FH8Y3"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{}"
+										}
+									]
+								},
+								{
+									"name": "List all workflows in a specific instance",
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/amc/reporting/{{instanceId}}/workflows?nextToken=&limit=",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"amc",
+												"reporting",
+												"{{instanceId}}",
+												"workflows"
+											],
+											"query": [
+												{
+													"key": "nextToken",
+													"value": "",
+													"description": "Optional. Token to retrieve subsequent page of results."
+												},
+												{
+													"key": "limit",
+													"value": "",
+													"description": "Optional. Limits the number of items to return in the response. Max value is 100. Defaults to 100."
+												}
+											]
+										},
+										"description": "Returns a list of workflows. Workflows are defined as a set of operations that take previously defined data sources as input and use them to generate reports."
+									},
+									"response": [
+										{
+											"name": "List all workflows in a specific instance",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+													},
+													{
+														"key": "Amazon-Advertising-API-Scope",
+														"value": "<string>",
+														"description": "This header is deprecated.   Clients must pass in Amazon-Advertising-API-AdvertiserId and Amazon-Advertising-API-MarketplaceId as headers",
+														"disabled": true
+													},
+													{
+														"key": "Amazon-Advertising-API-AdvertiserId",
+														"value": "{{advertiser_id}}",
+														"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+													},
+													{
+														"key": "Amazon-Advertising-API-MarketplaceId",
+														"value": "{{marketplace_id}}",
+														"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+													},
+													{
+														"key": "Accept",
+														"value": "application/vnd.amcworkflows.v1+json"
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{api_url}}/amc/reporting/:instanceId/workflows?nextToken=&limit=",
+													"host": [
+														"{{api_url}}"
+													],
+													"path": [
+														"amc",
+														"reporting",
+														":instanceId",
+														"workflows"
+													],
+													"query": [
+														{
+															"key": "nextToken",
+															"value": "",
+															"description": "Optional. Token to retrieve subsequent page of results."
+														},
+														{
+															"key": "limit",
+															"value": "",
+															"description": "Optional. Limits the number of items to return in the response. Max value is 100. Defaults to 100."
+														}
+													],
+													"variable": [
+														{
+															"key": "instanceId",
+															"value": "{{instanceId}}",
+															"description": "(Required) The AMC instance identifier required for operations that read or write to a specific AMC instance. This can be retrieved by making a GET request to /amc/instances endpoint or from the AMC UI through the Instance info page."
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Wed, 25 Sep 2024 02:16:48 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/vnd.amcworkflows.v1+json"
+												},
+												{
+													"key": "Transfer-Encoding",
+													"value": "chunked"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "GADFY5BK4RJSA3YYCRGA"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "GADFY5BK4RJSA3YYCRGA"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"workflows\": [\n        {\n            \"inputParameters\": [\n                {\n                    \"dataType\": {\n                        \"type\": \"ARRAY\",\n                        \"elementDataType\": \"STRING\",\n                        \"elementNullable\": false\n                    },\n                    \"defaultValue\": [\n                        \"ALL\"\n                    ],\n                    \"description\": \"Enter description for parameter\",\n                    \"name\": \"sa_campaigns\"\n                }\n            ],\n            \"sqlQuery\": \"SELECT campaign, SUM(IMPRESSIONS) AS Impressions FROM sponsored_ads_traffic WHERE ARRAY_CONTAINS(CUSTOM_PARAMETER('sa_campaigns'), 'ALL') OR ARRAY_CONTAINS(CUSTOM_PARAMETER('sa_campaigns'), campaign) GROUP BY 1\",\n            \"workflowId\": \"my-first-workflow-with-custom-parameters\"\n        },\n        {\n            \"inputParameters\": [\n                {\n                    \"dataType\": {\n                        \"type\": \"ARRAY\",\n                        \"elementDataType\": \"STRING\",\n                        \"elementNullable\": false\n                    },\n                    \"defaultValue\": [\n                        \"ALL\"\n                    ],\n                    \"description\": \"Enter description for parameter\",\n                    \"name\": \"sa_campaigns\"\n                }\n            ],\n            \"sqlQuery\": \"SELECT campaign, SUM(IMPRESSIONS) AS Impressions FROM sponsored_ads_traffic WHERE ARRAY_CONTAINS(CUSTOM_PARAMETER('sa_campaigns'), 'ALL') OR ARRAY_CONTAINS(CUSTOM_PARAMETER('sa_campaigns'), campaign) GROUP BY 1\",\n            \"workflowId\": \"AAAAA\"\n        },\n        {\n            \"outputColumns\": [\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"advertiser_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"advertiser\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"campaign_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"campaign\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_start_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_end_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"DATE\",\n                    \"name\": \"date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"DOUBLE\",\n                    \"name\": \"frequency\"\n                }\n            ],\n            \"query\": {\n                \"operations\": [\n                    {\n                        \"type\": \"Select\",\n                        \"columns\": [\n                            \"impression_date\",\n                            \"advertiser_id\",\n                            \"advertiser\",\n                            \"campaign_id\",\n                            \"campaign\",\n                            \"campaign_start_date\",\n                            \"campaign_end_date\",\n                            \"impressions\",\n                            \"user_id\"\n                        ],\n                        \"inputData\": \"dsp_impressions\",\n                        \"maxTimeAfterWindow\": \"PT0S\",\n                        \"maxTimeBeforeWindow\": \"PT0S\",\n                        \"name\": \"select_impressions\"\n                    },\n                    {\n                        \"type\": \"RenameColumns\",\n                        \"inputColumns\": [\n                            \"impression_date\"\n                        ],\n                        \"name\": \"Rename\",\n                        \"outputColumns\": [\n                            \"date\"\n                        ]\n                    },\n                    {\n                        \"type\": \"Aggregate\",\n                        \"aggregationType\": \"SUM\",\n                        \"columnAggregationTypes\": {\n                            \"user_id\": \"COUNT_DISTINCT\"\n                        },\n                        \"name\": \"SumMetrics\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"Divide\",\n                            \"firstValue\": {\n                                \"type\": \"Cast\",\n                                \"dataType\": \"DOUBLE\",\n                                \"value\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                }\n                            },\n                            \"secondValue\": {\n                                \"type\": \"Column\",\n                                \"column\": \"user_id\"\n                            }\n                        },\n                        \"name\": \"CalculateFrequency\",\n                        \"outputColumn\": \"frequency\"\n                    },\n                    {\n                        \"type\": \"DropColumns\",\n                        \"columns\": [\n                            \"user_id\",\n                            \"impressions\"\n                        ],\n                        \"name\": \"DropIntermediateColumns\"\n                    }\n                ]\n            },\n            \"workflowId\": \"standard_frequency\"\n        },\n        {\n            \"outputColumns\": [\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"advertiser_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"advertiser\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"campaign_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"campaign\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_start_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_end_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"DATE\",\n                    \"name\": \"date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"frequency_buckets\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"users_in_bucket\"\n                }\n            ],\n            \"query\": {\n                \"operations\": [\n                    {\n                        \"type\": \"Select\",\n                        \"columns\": [\n                            \"impression_date\",\n                            \"advertiser_id\",\n                            \"advertiser\",\n                            \"campaign_id\",\n                            \"campaign\",\n                            \"campaign_start_date\",\n                            \"campaign_end_date\",\n                            \"impressions\",\n                            \"user_id\"\n                        ],\n                        \"inputData\": \"dsp_impressions\",\n                        \"maxTimeAfterWindow\": \"PT0S\",\n                        \"maxTimeBeforeWindow\": \"PT0S\",\n                        \"name\": \"select_impressions\"\n                    },\n                    {\n                        \"type\": \"RenameColumns\",\n                        \"inputColumns\": [\n                            \"impression_date\"\n                        ],\n                        \"name\": \"Rename\",\n                        \"outputColumns\": [\n                            \"date\"\n                        ]\n                    },\n                    {\n                        \"type\": \"Aggregate\",\n                        \"aggregationType\": \"SUM\",\n                        \"name\": \"SumMetrics\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"LessThan\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"10\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"DIMENSION\",\n                                \"dataType\": \"STRING\",\n                                \"value\": \"frequency_10+\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Concatenate\",\n                                \"values\": [\n                                    {\n                                        \"type\": \"Literal\",\n                                        \"columnType\": \"DIMENSION\",\n                                        \"dataType\": \"STRING\",\n                                        \"value\": \"frequency_\"\n                                    },\n                                    {\n                                        \"type\": \"Column\",\n                                        \"column\": \"impressions\"\n                                    }\n                                ]\n                            }\n                        },\n                        \"name\": \"DefineFrequencyBuckets\",\n                        \"outputColumn\": \"frequency_buckets\"\n                    },\n                    {\n                        \"type\": \"Aggregate\",\n                        \"aggregationType\": \"SUM\",\n                        \"columnAggregationTypes\": {\n                            \"user_id\": \"COUNT_DISTINCT\"\n                        },\n                        \"name\": \"CountUsersInBuckets\"\n                    },\n                    {\n                        \"type\": \"RenameColumns\",\n                        \"inputColumns\": [\n                            \"user_id\"\n                        ],\n                        \"name\": \"Rename\",\n                        \"outputColumns\": [\n                            \"users_in_bucket\"\n                        ]\n                    },\n                    {\n                        \"type\": \"DropColumns\",\n                        \"columns\": [\n                            \"impressions\"\n                        ],\n                        \"name\": \"DropIntermediateColumns\"\n                    }\n                ]\n            },\n            \"workflowId\": \"standard_frequency-buckets\"\n        },\n        {\n            \"outputColumns\": [\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"advertiser_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"advertiser\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"campaign_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"campaign\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_start_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_end_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"browser_family\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"impressions\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"DATE\",\n                    \"name\": \"date\"\n                }\n            ],\n            \"query\": {\n                \"operations\": [\n                    {\n                        \"type\": \"Select\",\n                        \"columns\": [\n                            \"impression_date\",\n                            \"advertiser_id\",\n                            \"advertiser\",\n                            \"campaign_id\",\n                            \"campaign\",\n                            \"campaign_start_date\",\n                            \"campaign_end_date\",\n                            \"browser_family\",\n                            \"impressions\"\n                        ],\n                        \"inputData\": \"dsp_impressions\",\n                        \"maxTimeAfterWindow\": \"PT0S\",\n                        \"maxTimeBeforeWindow\": \"PT0S\",\n                        \"name\": \"select_impressions\"\n                    },\n                    {\n                        \"type\": \"RenameColumns\",\n                        \"inputColumns\": [\n                            \"impression_date\"\n                        ],\n                        \"name\": \"rename\",\n                        \"outputColumns\": [\n                            \"date\"\n                        ]\n                    },\n                    {\n                        \"type\": \"Aggregate\",\n                        \"aggregationType\": \"SUM\",\n                        \"name\": \"SumMetrics\"\n                    }\n                ]\n            },\n            \"workflowId\": \"standard_impressions-by-browser-family\"\n        },\n        {\n            \"outputColumns\": [\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"advertiser_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"advertiser\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"campaign_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"campaign\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_start_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_end_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"device_type\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"impressions\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"DATE\",\n                    \"name\": \"date\"\n                }\n            ],\n            \"query\": {\n                \"operations\": [\n                    {\n                        \"type\": \"Select\",\n                        \"columns\": [\n                            \"impression_date\",\n                            \"advertiser_id\",\n                            \"advertiser\",\n                            \"campaign_id\",\n                            \"campaign\",\n                            \"campaign_start_date\",\n                            \"campaign_end_date\",\n                            \"device_type\",\n                            \"impressions\"\n                        ],\n                        \"inputData\": \"dsp_impressions\",\n                        \"maxTimeAfterWindow\": \"PT0S\",\n                        \"maxTimeBeforeWindow\": \"PT0S\",\n                        \"name\": \"select_impressions\"\n                    },\n                    {\n                        \"type\": \"RenameColumns\",\n                        \"inputColumns\": [\n                            \"impression_date\"\n                        ],\n                        \"name\": \"rename\",\n                        \"outputColumns\": [\n                            \"date\"\n                        ]\n                    },\n                    {\n                        \"type\": \"Aggregate\",\n                        \"aggregationType\": \"SUM\",\n                        \"name\": \"SumMetrics\"\n                    }\n                ]\n            },\n            \"workflowId\": \"standard_impressions-by-device-type\"\n        },\n        {\n            \"outputColumns\": [\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"advertiser_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"advertiser\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"campaign_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"campaign\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_start_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_end_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"dma_code\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"impressions\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"DATE\",\n                    \"name\": \"date\"\n                }\n            ],\n            \"query\": {\n                \"operations\": [\n                    {\n                        \"type\": \"Select\",\n                        \"columns\": [\n                            \"impression_date\",\n                            \"advertiser_id\",\n                            \"advertiser\",\n                            \"campaign_id\",\n                            \"campaign\",\n                            \"campaign_start_date\",\n                            \"campaign_end_date\",\n                            \"dma_code\",\n                            \"impressions\"\n                        ],\n                        \"inputData\": \"dsp_impressions\",\n                        \"maxTimeAfterWindow\": \"PT0S\",\n                        \"maxTimeBeforeWindow\": \"PT0S\",\n                        \"name\": \"select_impressions\"\n                    },\n                    {\n                        \"type\": \"RenameColumns\",\n                        \"inputColumns\": [\n                            \"impression_date\"\n                        ],\n                        \"name\": \"rename\",\n                        \"outputColumns\": [\n                            \"date\"\n                        ]\n                    },\n                    {\n                        \"type\": \"Aggregate\",\n                        \"aggregationType\": \"SUM\",\n                        \"name\": \"SumMetrics\"\n                    }\n                ]\n            },\n            \"workflowId\": \"standard_impressions-by-dma\"\n        },\n        {\n            \"outputColumns\": [\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"advertiser_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"advertiser\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"campaign_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"campaign\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_start_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_end_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"operating_system\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"impressions\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"DATE\",\n                    \"name\": \"date\"\n                }\n            ],\n            \"query\": {\n                \"operations\": [\n                    {\n                        \"type\": \"Select\",\n                        \"columns\": [\n                            \"impression_date\",\n                            \"advertiser_id\",\n                            \"advertiser\",\n                            \"campaign_id\",\n                            \"campaign\",\n                            \"campaign_start_date\",\n                            \"campaign_end_date\",\n                            \"operating_system\",\n                            \"impressions\"\n                        ],\n                        \"inputData\": \"dsp_impressions\",\n                        \"maxTimeAfterWindow\": \"PT0S\",\n                        \"maxTimeBeforeWindow\": \"PT0S\",\n                        \"name\": \"select_impressions\"\n                    },\n                    {\n                        \"type\": \"RenameColumns\",\n                        \"inputColumns\": [\n                            \"impression_date\"\n                        ],\n                        \"name\": \"rename\",\n                        \"outputColumns\": [\n                            \"date\"\n                        ]\n                    },\n                    {\n                        \"type\": \"Aggregate\",\n                        \"aggregationType\": \"SUM\",\n                        \"name\": \"SumMetrics\"\n                    }\n                ]\n            },\n            \"workflowId\": \"standard_impressions-by-operating-system\"\n        },\n        {\n            \"outputColumns\": [\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"advertiser_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"advertiser\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"campaign_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"campaign\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_start_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_end_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"site\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"supply_source\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"impressions\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"DATE\",\n                    \"name\": \"date\"\n                }\n            ],\n            \"query\": {\n                \"operations\": [\n                    {\n                        \"type\": \"Select\",\n                        \"columns\": [\n                            \"impression_date\",\n                            \"advertiser_id\",\n                            \"advertiser\",\n                            \"campaign_id\",\n                            \"campaign\",\n                            \"campaign_start_date\",\n                            \"campaign_end_date\",\n                            \"site\",\n                            \"supply_source\",\n                            \"impressions\"\n                        ],\n                        \"inputData\": \"dsp_impressions\",\n                        \"maxTimeAfterWindow\": \"PT0S\",\n                        \"maxTimeBeforeWindow\": \"PT0S\",\n                        \"name\": \"select_impressions\"\n                    },\n                    {\n                        \"type\": \"RenameColumns\",\n                        \"inputColumns\": [\n                            \"impression_date\"\n                        ],\n                        \"name\": \"rename\",\n                        \"outputColumns\": [\n                            \"date\"\n                        ]\n                    },\n                    {\n                        \"type\": \"Aggregate\",\n                        \"aggregationType\": \"SUM\",\n                        \"name\": \"SumMetrics\"\n                    }\n                ]\n            },\n            \"workflowId\": \"standard_impressions-by-site-and-supply-source\"\n        },\n        {\n            \"outputColumns\": [\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"DATE\",\n                    \"name\": \"date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"INTEGER\",\n                    \"name\": \"hour\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"entity_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"advertiser_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"advertiser\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"campaign_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"campaign\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_start_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_end_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"line_item_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"line_item\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"line_item_type\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"line_item_start_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"line_item_end_date\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"impressions\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"clicks\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"supply_cost\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"audience_fee\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"third_party_fees\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"platform_fee\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"DOUBLE\",\n                    \"name\": \"total_cost\"\n                }\n            ],\n            \"query\": {\n                \"operations\": [\n                    {\n                        \"type\": \"Select\",\n                        \"columns\": [\n                            \"impression_date\",\n                            \"impression_hour\",\n                            \"entity_id\",\n                            \"advertiser_id\",\n                            \"advertiser\",\n                            \"campaign_id\",\n                            \"campaign\",\n                            \"campaign_start_date\",\n                            \"campaign_end_date\",\n                            \"line_item_id\",\n                            \"line_item\",\n                            \"line_item_type\",\n                            \"line_item_start_date\",\n                            \"line_item_end_date\",\n                            \"impressions\",\n                            \"supply_cost\",\n                            \"audience_fee\",\n                            \"third_party_fees\",\n                            \"platform_fee\",\n                            \"total_cost\",\n                            \"request_tag\"\n                        ],\n                        \"inputData\": \"dsp_impressions\",\n                        \"maxTimeAfterWindow\": \"PT0S\",\n                        \"maxTimeBeforeWindow\": \"PT0S\",\n                        \"name\": \"select_impressions\"\n                    },\n                    {\n                        \"type\": \"RenameColumns\",\n                        \"inputColumns\": [\n                            \"impression_date\",\n                            \"impression_hour\"\n                        ],\n                        \"outputColumns\": [\n                            \"date\",\n                            \"hour\"\n                        ]\n                    },\n                    {\n                        \"type\": \"Join\",\n                        \"firstKeyColumns\": [\n                            \"request_tag\"\n                        ],\n                        \"joinType\": \"LEFT\",\n                        \"maxTimeAfterWindow\": \"PT0S\",\n                        \"maxTimeBeforeWindow\": \"PT0S\",\n                        \"optional\": false,\n                        \"secondIncludedColumns\": [\n                            \"clicks\"\n                        ],\n                        \"secondInputData\": \"dsp_clicks\",\n                        \"secondKeyColumns\": [\n                            \"request_tag\"\n                        ]\n                    },\n                    {\n                        \"type\": \"DropColumns\",\n                        \"columns\": [\n                            \"request_tag\"\n                        ]\n                    },\n                    {\n                        \"type\": \"Aggregate\",\n                        \"aggregationType\": \"SUM\",\n                        \"name\": \"SumMetrics\"\n                    },\n                    {\n                        \"type\": \"Select\",\n                        \"columns\": [\n                            \"date\",\n                            \"hour\",\n                            \"entity_id\",\n                            \"advertiser_id\",\n                            \"advertiser\",\n                            \"campaign_id\",\n                            \"campaign\",\n                            \"campaign_start_date\",\n                            \"campaign_end_date\",\n                            \"line_item_id\",\n                            \"line_item\",\n                            \"line_item_type\",\n                            \"line_item_start_date\",\n                            \"line_item_end_date\",\n                            \"impressions\",\n                            \"clicks\",\n                            \"supply_cost\",\n                            \"audience_fee\",\n                            \"third_party_fees\",\n                            \"platform_fee\",\n                            \"total_cost\"\n                        ],\n                        \"maxTimeAfterWindow\": \"PT0S\",\n                        \"maxTimeBeforeWindow\": \"PT0S\"\n                    }\n                ]\n            },\n            \"workflowId\": \"standard_intraday-delivery\"\n        },\n        {\n            \"outputColumns\": [\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"advertiser_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"advertiser\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"campaign_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"campaign\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_start_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_end_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"DATE\",\n                    \"name\": \"date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"reach\"\n                }\n            ],\n            \"query\": {\n                \"operations\": [\n                    {\n                        \"type\": \"Select\",\n                        \"columns\": [\n                            \"impression_date\",\n                            \"advertiser_id\",\n                            \"advertiser\",\n                            \"campaign_id\",\n                            \"campaign\",\n                            \"campaign_start_date\",\n                            \"campaign_end_date\",\n                            \"user_id\"\n                        ],\n                        \"inputData\": \"dsp_impressions\",\n                        \"maxTimeAfterWindow\": \"PT0S\",\n                        \"maxTimeBeforeWindow\": \"PT0S\",\n                        \"name\": \"select_impressions\"\n                    },\n                    {\n                        \"type\": \"RenameColumns\",\n                        \"inputColumns\": [\n                            \"impression_date\",\n                            \"user_id\"\n                        ],\n                        \"name\": \"Rename\",\n                        \"outputColumns\": [\n                            \"date\",\n                            \"reach\"\n                        ]\n                    },\n                    {\n                        \"type\": \"Aggregate\",\n                        \"aggregationType\": \"SUM\",\n                        \"columnAggregationTypes\": {\n                            \"reach\": \"COUNT_DISTINCT\"\n                        },\n                        \"name\": \"SumMetrics\"\n                    }\n                ]\n            },\n            \"workflowId\": \"standard_reach\"\n        },\n        {\n            \"outputColumns\": [\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"DATE\",\n                    \"name\": \"date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"advertiser_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"advertiser\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"campaign_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"campaign\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_start_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_end_date\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"impressions\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"reach\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"DOUBLE\",\n                    \"name\": \"average_frequency\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_1\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_2\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_3\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_4\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_5\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_6\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_7\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_8\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_9\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_10\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_11\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_12\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_13\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_14\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_15\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_16\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_17\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_18\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_19\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_20\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_over_20\"\n                }\n            ],\n            \"query\": {\n                \"operations\": [\n                    {\n                        \"type\": \"Select\",\n                        \"columns\": [\n                            \"impression_date\",\n                            \"advertiser_id\",\n                            \"advertiser\",\n                            \"campaign_id\",\n                            \"campaign\",\n                            \"campaign_start_date\",\n                            \"campaign_end_date\",\n                            \"impressions\",\n                            \"user_id\"\n                        ],\n                        \"inputData\": \"dsp_impressions\",\n                        \"maxTimeAfterWindow\": \"PT0S\",\n                        \"maxTimeBeforeWindow\": \"PT0S\"\n                    },\n                    {\n                        \"type\": \"RenameColumns\",\n                        \"inputColumns\": [\n                            \"impression_date\"\n                        ],\n                        \"outputColumns\": [\n                            \"date\"\n                        ]\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"Column\",\n                            \"column\": \"user_id\"\n                        },\n                        \"outputColumn\": \"reach\"\n                    },\n                    {\n                        \"type\": \"Aggregate\",\n                        \"aggregationType\": \"SUM\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"Column\",\n                            \"column\": \"impressions\"\n                        },\n                        \"outputColumn\": \"average_frequency\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"1\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_1\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"2\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_2\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"3\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_3\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"4\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_4\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"5\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_5\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"6\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_6\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"7\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_7\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"8\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_8\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"9\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_9\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"10\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_10\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"11\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_11\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"12\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_12\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"13\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_13\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"14\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_14\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"15\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_15\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"16\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_16\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"17\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_17\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"18\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_18\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"19\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_19\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"20\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_20\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"GreaterThan\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"20\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_over_20\"\n                    },\n                    {\n                        \"type\": \"DropColumns\",\n                        \"columns\": [\n                            \"user_id\"\n                        ]\n                    },\n                    {\n                        \"type\": \"Aggregate\",\n                        \"aggregationType\": \"SUM\",\n                        \"columnAggregationTypes\": {\n                            \"average_frequency\": \"AVERAGE\",\n                            \"reach\": \"COUNT_DISTINCT\"\n                        }\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"Classify\",\n                            \"columnType\": \"DIMENSION\",\n                            \"value\": {\n                                \"type\": \"Column\",\n                                \"column\": \"average_frequency\"\n                            }\n                        }\n                    },\n                    {\n                        \"type\": \"Select\",\n                        \"columns\": [\n                            \"date\",\n                            \"advertiser_id\",\n                            \"advertiser\",\n                            \"campaign_id\",\n                            \"campaign\",\n                            \"campaign_start_date\",\n                            \"campaign_end_date\",\n                            \"impressions\",\n                            \"reach\",\n                            \"average_frequency\",\n                            \"frequency_1\",\n                            \"frequency_2\",\n                            \"frequency_3\",\n                            \"frequency_4\",\n                            \"frequency_5\",\n                            \"frequency_6\",\n                            \"frequency_7\",\n                            \"frequency_8\",\n                            \"frequency_9\",\n                            \"frequency_10\",\n                            \"frequency_11\",\n                            \"frequency_12\",\n                            \"frequency_13\",\n                            \"frequency_14\",\n                            \"frequency_15\",\n                            \"frequency_16\",\n                            \"frequency_17\",\n                            \"frequency_18\",\n                            \"frequency_19\",\n                            \"frequency_20\",\n                            \"frequency_over_20\"\n                        ],\n                        \"maxTimeAfterWindow\": \"PT0S\",\n                        \"maxTimeBeforeWindow\": \"PT0S\"\n                    }\n                ]\n            },\n            \"workflowId\": \"standard_reach-frequency\"\n        },\n        {\n            \"outputColumns\": [\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"DATE\",\n                    \"name\": \"date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"advertiser_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"advertiser\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"campaign_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"campaign\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_start_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"campaign_end_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"line_item_id\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"line_item\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"line_item_type\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"line_item_start_date\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"TIMESTAMP\",\n                    \"name\": \"line_item_end_date\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"impressions\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"reach\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"DOUBLE\",\n                    \"name\": \"average_frequency\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_1\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_2\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_3\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_4\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_5\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_6\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_7\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_8\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_9\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_10\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_11\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_12\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_13\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_14\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_15\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_16\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_17\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_18\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_19\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_20\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"frequency_over_20\"\n                }\n            ],\n            \"query\": {\n                \"operations\": [\n                    {\n                        \"type\": \"Select\",\n                        \"columns\": [\n                            \"impression_date\",\n                            \"advertiser_id\",\n                            \"advertiser\",\n                            \"campaign_id\",\n                            \"campaign\",\n                            \"campaign_start_date\",\n                            \"campaign_end_date\",\n                            \"line_item_id\",\n                            \"line_item\",\n                            \"line_item_type\",\n                            \"line_item_start_date\",\n                            \"line_item_end_date\",\n                            \"impressions\",\n                            \"user_id\"\n                        ],\n                        \"inputData\": \"dsp_impressions\",\n                        \"maxTimeAfterWindow\": \"PT0S\",\n                        \"maxTimeBeforeWindow\": \"PT0S\"\n                    },\n                    {\n                        \"type\": \"RenameColumns\",\n                        \"inputColumns\": [\n                            \"impression_date\"\n                        ],\n                        \"outputColumns\": [\n                            \"date\"\n                        ]\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"Column\",\n                            \"column\": \"user_id\"\n                        },\n                        \"outputColumn\": \"reach\"\n                    },\n                    {\n                        \"type\": \"Aggregate\",\n                        \"aggregationType\": \"SUM\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"Column\",\n                            \"column\": \"impressions\"\n                        },\n                        \"outputColumn\": \"average_frequency\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"1\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_1\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"2\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_2\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"3\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_3\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"4\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_4\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"5\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_5\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"6\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_6\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"7\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_7\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"8\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_8\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"9\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_9\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"10\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_10\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"11\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_11\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"12\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_12\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"13\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_13\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"14\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_14\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"15\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_15\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"16\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_16\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"17\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_17\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"18\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_18\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"19\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_19\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"Equals\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"20\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_20\"\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"IfElse\",\n                            \"condition\": {\n                                \"type\": \"GreaterThan\",\n                                \"firstValue\": {\n                                    \"type\": \"Column\",\n                                    \"column\": \"impressions\"\n                                },\n                                \"secondValue\": {\n                                    \"type\": \"Literal\",\n                                    \"value\": \"20\"\n                                }\n                            },\n                            \"falseValue\": {\n                                \"type\": \"Literal\",\n                                \"value\": \"0\"\n                            },\n                            \"trueValue\": {\n                                \"type\": \"Literal\",\n                                \"columnType\": \"METRIC\",\n                                \"dataType\": \"LONG\",\n                                \"value\": \"1\"\n                            }\n                        },\n                        \"outputColumn\": \"frequency_over_20\"\n                    },\n                    {\n                        \"type\": \"DropColumns\",\n                        \"columns\": [\n                            \"user_id\"\n                        ]\n                    },\n                    {\n                        \"type\": \"Aggregate\",\n                        \"aggregationType\": \"SUM\",\n                        \"columnAggregationTypes\": {\n                            \"average_frequency\": \"AVERAGE\",\n                            \"reach\": \"COUNT_DISTINCT\"\n                        }\n                    },\n                    {\n                        \"type\": \"Column\",\n                        \"expression\": {\n                            \"type\": \"Classify\",\n                            \"columnType\": \"DIMENSION\",\n                            \"value\": {\n                                \"type\": \"Column\",\n                                \"column\": \"average_frequency\"\n                            }\n                        }\n                    },\n                    {\n                        \"type\": \"Select\",\n                        \"columns\": [\n                            \"date\",\n                            \"advertiser_id\",\n                            \"advertiser\",\n                            \"campaign_id\",\n                            \"campaign\",\n                            \"campaign_start_date\",\n                            \"campaign_end_date\",\n                            \"line_item_id\",\n                            \"line_item\",\n                            \"line_item_type\",\n                            \"line_item_start_date\",\n                            \"line_item_end_date\",\n                            \"impressions\",\n                            \"reach\",\n                            \"average_frequency\",\n                            \"frequency_1\",\n                            \"frequency_2\",\n                            \"frequency_3\",\n                            \"frequency_4\",\n                            \"frequency_5\",\n                            \"frequency_6\",\n                            \"frequency_7\",\n                            \"frequency_8\",\n                            \"frequency_9\",\n                            \"frequency_10\",\n                            \"frequency_11\",\n                            \"frequency_12\",\n                            \"frequency_13\",\n                            \"frequency_14\",\n                            \"frequency_15\",\n                            \"frequency_16\",\n                            \"frequency_17\",\n                            \"frequency_18\",\n                            \"frequency_19\",\n                            \"frequency_20\",\n                            \"frequency_over_20\"\n                        ],\n                        \"maxTimeAfterWindow\": \"PT0S\",\n                        \"maxTimeBeforeWindow\": \"PT0S\"\n                    }\n                ]\n            },\n            \"workflowId\": \"standard_reach-frequency-by-line-item\"\n        }\n    ]\n}"
+										}
+									]
+								},
+								{
+									"name": "Get the requested workflow",
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/amc/reporting/{{instanceId}}/workflows/:workflowId",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"amc",
+												"reporting",
+												"{{instanceId}}",
+												"workflows",
+												":workflowId"
+											],
+											"variable": [
+												{
+													"key": "workflowId",
+													"value": "my-first-workflow",
+													"description": "(Required) The requested workflow identifier."
+												}
+											]
+										}
+									},
+									"response": [
+										{
+											"name": "Gets the requested workflow",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+													},
+													{
+														"key": "Amazon-Advertising-API-Scope",
+														"value": "<string>",
+														"description": "This header is deprecated.   Clients must pass in Amazon-Advertising-API-AdvertiserId and Amazon-Advertising-API-MarketplaceId as headers",
+														"disabled": true
+													},
+													{
+														"key": "Amazon-Advertising-API-AdvertiserId",
+														"value": "{{advertiser_id}}",
+														"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+													},
+													{
+														"key": "Amazon-Advertising-API-MarketplaceId",
+														"value": "{{marketplace_id}}",
+														"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+													},
+													{
+														"key": "Accept",
+														"value": "application/vnd.amcworkflows.v1+json"
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{api_url}}/amc/reporting/:instanceId/workflows/:workflowId",
+													"host": [
+														"{{api_url}}"
+													],
+													"path": [
+														"amc",
+														"reporting",
+														":instanceId",
+														"workflows",
+														":workflowId"
+													],
+													"variable": [
+														{
+															"key": "instanceId",
+															"value": "{{instanceId}}",
+															"description": "(Required) The AMC instance identifier required for operations that read or write to a specific AMC instance. This can be retrieved by making a GET request to /amc/instances endpoint or from the AMC UI through the Instance info page."
+														},
+														{
+															"key": "workflowId",
+															"value": "my-first-workflow",
+															"description": "(Required) The requested workflow identifier."
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Wed, 25 Sep 2024 02:21:30 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/vnd.amcworkflows.v1+json"
+												},
+												{
+													"key": "Content-Length",
+													"value": "140"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "QAFGJV1A0Q7SAXVJE42N"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "QAFGJV1A0Q7SAXVJE42N"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"sqlQuery\": \"SELECT campaign_id,SUM(impressions) AS impressions FROM dsp_impressions GROUP by campaign_id\",\n    \"workflowId\": \"my-first-workflow\"\n}"
+										}
+									]
+								},
+								{
+									"name": "Update the requested workflow",
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"workflowId\": \"my-first-workflow\",\r\n    \"sqlQuery\": \"SELECT campaign_id,SUM(impressions) AS impressions FROM dsp_impressions GROUP by campaign_id\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{api_url}}/amc/reporting/{{instanceId}}/workflows/:workflowId",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"amc",
+												"reporting",
+												"{{instanceId}}",
+												"workflows",
+												":workflowId"
+											],
+											"variable": [
+												{
+													"key": "workflowId",
+													"value": "my-first-workflow"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete the requested workflow",
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/amc/reporting/{{instanceId}}/workflows/:workflowId",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"amc",
+												"reporting",
+												"{{instanceId}}",
+												"workflows",
+												":workflowId"
+											],
+											"variable": [
+												{
+													"key": "workflowId",
+													"value": "my-first-workflow",
+													"description": "(Required) The requested workflow identifier."
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Schedules",
+							"item": [
+								{
+									"name": "Create a new schedule",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"scheduleId\": \"my-first-schedule\",\n    \"workflowId\": \"my-first-workflow\",\n    \"aggregationHourUtc\": 14,\n    \"aggregationPeriod\": \"Weekly\",\n    \"aggregationStartDay\": \"Monday\",\n    \"scheduleEnabled\": true,\n    \"requireSyntheticData\": true,\n    \"disableAggregationControls\": true\n}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": "{{api_url}}/amc/reporting/{{instanceId}}/schedules",
+										"description": "Creates a new schedule. Schedules are used to specify the periodic execution of a given workflow, on either a daily or weekly cadence."
+									},
+									"response": []
+								},
+								{
+									"name": "List all schedules",
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"url": "{{api_url}}/amc/reporting/{{instanceId}}/schedules",
+										"description": "Gets the requested schedule. Schedules are used to specify the periodic execution of a given workflow, on either a daily or weekly cadence."
+									},
+									"response": [
+										{
+											"name": "Returns a list of schedules",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+													},
+													{
+														"key": "Amazon-Advertising-API-Scope",
+														"value": "<string>",
+														"description": "This header is deprecated.   Clients must pass in Amazon-Advertising-API-AdvertiserId and Amazon-Advertising-API-MarketplaceId as headers",
+														"disabled": true
+													},
+													{
+														"key": "Amazon-Advertising-API-AdvertiserId",
+														"value": "{{advertiser_id}}",
+														"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+													},
+													{
+														"key": "Amazon-Advertising-API-MarketplaceId",
+														"value": "{{marketplace_id}}",
+														"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+													},
+													{
+														"key": "Accept",
+														"value": "application/vnd.amcschedules.v1+json"
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													}
+												],
+												"url": "{{api_url}}/amc/reporting/{{instanceId}}/schedules"
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Wed, 25 Sep 2024 03:03:10 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/vnd.amcschedules.v1+json"
+												},
+												{
+													"key": "Content-Length",
+													"value": "490"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "D23WVF3FSK7YH0AV3W40"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "D23WVF3FSK7YH0AV3W40"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"schedules\": [\n        {\n            \"aggregationHourUtc\": 14,\n            \"aggregationPeriod\": \"Weekly\",\n            \"aggregationStartDay\": \"Monday\",\n            \"disableAggregationControls\": true,\n            \"requireSyntheticData\": true,\n            \"scheduleEnabled\": true,\n            \"scheduleId\": \"my-first-schedule\",\n            \"workflowId\": \"my-first-workflow\"\n        },\n        {\n            \"aggregationHourUtc\": 14,\n            \"aggregationPeriod\": \"Weekly\",\n            \"aggregationStartDay\": \"Monday\",\n            \"disableAggregationControls\": true,\n            \"requireSyntheticData\": true,\n            \"scheduleEnabled\": true,\n            \"scheduleId\": \"my-first-schedule1\",\n            \"workflowId\": \"my-first-workflow\"\n        }\n    ]\n}"
+										}
+									]
+								},
+								{
+									"name": "Gets the requested schedule",
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/amc/reporting/{{instanceId}}/schedules/:scheduleId",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"amc",
+												"reporting",
+												"{{instanceId}}",
+												"schedules",
+												":scheduleId"
+											],
+											"variable": [
+												{
+													"key": "scheduleId",
+													"value": "my-first-schedule"
+												}
+											]
+										},
+										"description": "Gets the requested schedule. Schedules are used to specify the periodic execution of a given workflow, on either a daily or weekly cadence."
+									},
+									"response": [
+										{
+											"name": "Gets the requested schedule",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+													},
+													{
+														"key": "Amazon-Advertising-API-Scope",
+														"value": "<string>",
+														"description": "This header is deprecated.   Clients must pass in Amazon-Advertising-API-AdvertiserId and Amazon-Advertising-API-MarketplaceId as headers",
+														"disabled": true
+													},
+													{
+														"key": "Amazon-Advertising-API-AdvertiserId",
+														"value": "{{advertiser_id}}",
+														"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+													},
+													{
+														"key": "Amazon-Advertising-API-MarketplaceId",
+														"value": "{{marketplace_id}}",
+														"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+													},
+													{
+														"key": "Accept",
+														"value": "application/vnd.amcschedules.v1+json"
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{api_url}}/amc/reporting/{{instanceId}}/schedules/:scheduleId",
+													"host": [
+														"{{api_url}}"
+													],
+													"path": [
+														"amc",
+														"reporting",
+														"{{instanceId}}",
+														"schedules",
+														":scheduleId"
+													],
+													"variable": [
+														{
+															"key": "scheduleId",
+															"value": "my-first-schedule"
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Wed, 25 Sep 2024 03:04:12 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/vnd.amcschedules.v1+json"
+												},
+												{
+													"key": "Content-Length",
+													"value": "236"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "CBFRNJFPDZVA10SNPCV7"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "CBFRNJFPDZVA10SNPCV7"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"aggregationHourUtc\": 14,\n    \"aggregationPeriod\": \"Weekly\",\n    \"aggregationStartDay\": \"Monday\",\n    \"disableAggregationControls\": true,\n    \"requireSyntheticData\": true,\n    \"scheduleEnabled\": true,\n    \"scheduleId\": \"my-first-schedule\",\n    \"workflowId\": \"my-first-workflow\"\n}"
+										}
+									]
+								},
+								{
+									"name": "Updates the requested schedule",
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"scheduleId\": \"my-first-schedule\",\n  \"workflowId\": \"my-first-workflow-of-the-day\",\n  \"aggregationHourUtc\": 8,\n  \"aggregationPeriod\": \"Weekly\",\n  \"aggregationStartDay\": \"Monday\",\n    \"scheduleEnabled\": true\n}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{api_url}}/amc/reporting/{{instanceId}}/schedules/:scheduleId",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"amc",
+												"reporting",
+												"{{instanceId}}",
+												"schedules",
+												":scheduleId"
+											],
+											"variable": [
+												{
+													"key": "scheduleId",
+													"value": "my-first-schedule",
+													"description": "(Required) The requested schedule identifier."
+												}
+											]
+										},
+										"description": "Updates the requested schedule. The request body is used as the new schedule definition."
+									},
+									"response": []
+								},
+								{
+									"name": "Deletes the requested schedule",
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/amc/reporting/{{instanceId}}/schedules/:scheduleId",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"amc",
+												"reporting",
+												"{{instanceId}}",
+												"schedules",
+												":scheduleId"
+											],
+											"variable": [
+												{
+													"key": "scheduleId",
+													"value": "my-first-schedule"
+												}
+											]
+										},
+										"description": "Deletes the requested schedule. The workflow associated with the schedule will no longer be executed on the specified cadence."
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Workflow executions",
+							"item": [
+								{
+									"name": "Creates a new workflow execution",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"workflowId\":\"my-first-workflow\",\n    \"timeWindowStart\": \"2024-01-20T00:00:00\",\n    \"timeWindowEnd\": \"2024-01-25T00:00:00\",\n    \"timeWindowType\": \"EXPLICIT\",\n    \"timeWindowTimeZone\": \"America/New_York\"\n}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": "{{api_url}}/amc/reporting/{{instanceId}}/workflowExecutions",
+										"description": "Creates a new, ad-hoc execution of an existing workflow. Workflow executions are asyncronous and will typically take at least 15 minutes to execute. Ad-hoc executions can be used for testing, development, or one-off reporting use-cases; periodic executions can be achieved by creating a schedule for a given workflow.\n\nThe output from the execution will be placed in your S3 bucket in a similar location to normal scheduled executions, and the location can be found by looking at the OutputS3URI property of a workflow execution. At this time, adhoc workflow executions may be run up to 30 times per day, per AMC instance. This limit applies across all Workflow IDs."
+									},
+									"response": [
+										{
+											"name": "Creates a new workflow execution",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+													},
+													{
+														"key": "Amazon-Advertising-API-MarketplaceId",
+														"value": "{{marketplace_id}}",
+														"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+													},
+													{
+														"key": "Amazon-Advertising-API-AdvertiserId",
+														"value": "{{advertiser_id}}",
+														"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"workflowId\":\"my-first-workflow\",\n    \"timeWindowStart\": \"2024-01-20T00:00:00\",\n    \"timeWindowEnd\": \"2024-01-25T00:00:00\",\n    \"timeWindowType\": \"EXPLICIT\",\n    \"timeWindowTimeZone\": \"America/New_York\"\n}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": "{{api_url}}/amc/reporting/{{instanceId}}/workflowExecutions"
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Wed, 25 Sep 2024 03:11:52 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/vnd.amcworkflowexecutions.v1+json"
+												},
+												{
+													"key": "Content-Length",
+													"value": "646"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "N1YDDJ69Q8GSRXBPW38W"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "N1YDDJ69Q8GSRXBPW38W"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"createTime\": \"2024-09-25T03:11:52Z\",\n    \"dataGaps\": [],\n    \"disableAggregationControls\": false,\n    \"executionCategory\": \"AD_HOC\",\n    \"expireTime\": \"2024-09-26T03:11:52Z\",\n    \"ignoreDataGaps\": false,\n    \"lastUpdatedTime\": \"2024-09-25T03:11:52Z\",\n    \"parameterValues\": {},\n    \"status\": \"PENDING\",\n    \"timeWindowEnd\": \"2024-01-25T05:00:00Z\",\n    \"timeWindowEndOriginal\": \"2024-01-25T00:00:00\",\n    \"timeWindowStart\": \"2024-01-20T05:00:00Z\",\n    \"timeWindowStartOriginal\": \"2024-01-20T00:00:00\",\n    \"timeWindowTimeZoneOriginal\": \"America/New_York\",\n    \"waitUntil\": \"2024-09-25T02:11:52Z\",\n    \"workflowExecutionId\": \"b3a77999-7c8e-4289-9bf9-5da8f178536c\",\n    \"workflowExecutionTimeoutSeconds\": 21600,\n    \"workflowId\": \"my-first-workflow\"\n}"
+										}
+									]
+								},
+								{
+									"name": "Returns a list of workflow executions",
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/amc/reporting/{{instanceId}}/workflowExecutions?minCreationTime=&maxCreationTime=&timeZone=&workflowId=my-first-workflow&includeWorkflow=false",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"amc",
+												"reporting",
+												"{{instanceId}}",
+												"workflowExecutions"
+											],
+											"query": [
+												{
+													"key": "minCreationTime",
+													"value": ""
+												},
+												{
+													"key": "maxCreationTime",
+													"value": ""
+												},
+												{
+													"key": "timeZone",
+													"value": ""
+												},
+												{
+													"key": "workflowId",
+													"value": "my-first-workflow"
+												},
+												{
+													"key": "includeWorkflow",
+													"value": "false"
+												}
+											]
+										},
+										"description": "Returns a list of workflow executions. Gets status information about the requested workflow execution. Information includes the time windows of data on which the workflow is executing and the S3 path of the workflow output. Workflow executions are asynchronous invocations of a given reporting workflow, used for testing, development, and on-off reporting use-cases."
+									},
+									"response": [
+										{
+											"name": "Returns a list of workflow executions",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+													},
+													{
+														"key": "Amazon-Advertising-API-Scope",
+														"value": "<string>",
+														"description": "This header is deprecated.   Clients must pass in Amazon-Advertising-API-AdvertiserId and Amazon-Advertising-API-MarketplaceId as headers",
+														"disabled": true
+													},
+													{
+														"key": "Amazon-Advertising-API-AdvertiserId",
+														"value": "{{advertiser_id}}",
+														"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+													},
+													{
+														"key": "Amazon-Advertising-API-MarketplaceId",
+														"value": "{{marketplace_id}}",
+														"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+													},
+													{
+														"key": "Accept",
+														"value": "application/vnd.amcworkflowexecutions.v1+json"
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{api_url}}/amc/reporting/{{instanceId}}/workflowExecutions?minCreationTime=&maxCreationTime=&timeZone=&workflowId=my-first-workflow&includeWorkflow=false",
+													"host": [
+														"{{api_url}}"
+													],
+													"path": [
+														"amc",
+														"reporting",
+														"{{instanceId}}",
+														"workflowExecutions"
+													],
+													"query": [
+														{
+															"key": "minCreationTime",
+															"value": ""
+														},
+														{
+															"key": "maxCreationTime",
+															"value": ""
+														},
+														{
+															"key": "timeZone",
+															"value": ""
+														},
+														{
+															"key": "workflowId",
+															"value": "my-first-workflow"
+														},
+														{
+															"key": "includeWorkflow",
+															"value": "false"
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Wed, 25 Sep 2024 03:15:44 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/vnd.amcworkflowexecutions.v1+json"
+												},
+												{
+													"key": "Content-Length",
+													"value": "1145"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "AH194QQFJMS9QQH8XS4F"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "AH194QQFJMS9QQH8XS4F"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"executions\": [\n        {\n            \"availableTimeBeforeWindowSecs\": 0,\n            \"createTime\": \"2024-09-25T03:11:52Z\",\n            \"dataGaps\": [],\n            \"disableAggregationControls\": false,\n            \"executionCategory\": \"AD_HOC\",\n            \"executionTime\": 55,\n            \"expireTime\": \"2024-09-26T03:11:52Z\",\n            \"ignoreDataGaps\": false,\n            \"invalidationOffsetSecs\": 266400,\n            \"lastUpdatedTime\": \"2024-09-25T03:14:42Z\",\n            \"outputColumns\": [\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"advertiser\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"STRING\",\n                    \"name\": \"campaign\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"DOUBLE\",\n                    \"name\": \"spend\"\n                },\n                {\n                    \"columnType\": \"METRIC\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"impressions\"\n                },\n                {\n                    \"columnType\": \"DIMENSION\",\n                    \"dataType\": \"LONG\",\n                    \"name\": \"reach\"\n                }\n            ],\n            \"outputS3URI\": \"N/A\",\n            \"parameterValues\": {},\n            \"status\": \"SUCCEEDED\",\n            \"timeWindowEnd\": \"2024-01-25T05:00:00Z\",\n            \"timeWindowEndOriginal\": \"2024-01-25T00:00:00\",\n            \"timeWindowStart\": \"2024-01-20T05:00:00Z\",\n            \"timeWindowStartOriginal\": \"2024-01-20T00:00:00\",\n            \"timeWindowTimeZoneOriginal\": \"America/New_York\",\n            \"validatedTime\": \"2024-09-25T03:11:54.792Z\",\n            \"waitUntil\": \"2024-09-25T02:11:52Z\",\n            \"workflowExecutionId\": \"b3a77999-7c8e-4289-9bf9-5da8f178536c\",\n            \"workflowExecutionTimeoutSeconds\": 21600,\n            \"workflowId\": \"my-first-workflow\"\n        }\n    ]\n}"
+										}
+									]
+								},
+								{
+									"name": "Gets status information about the requested workflow execution.",
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/amc/reporting/{{instanceId}}/workflowExecutions/:workflowExecutionId?includeWorkflow=false",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"amc",
+												"reporting",
+												"{{instanceId}}",
+												"workflowExecutions",
+												":workflowExecutionId"
+											],
+											"query": [
+												{
+													"key": "includeWorkflow",
+													"value": "false",
+													"description": "Optional. If 'true' includes the workflow definition in the response."
+												}
+											],
+											"variable": [
+												{
+													"key": "workflowExecutionId",
+													"value": "b3a77999-7c8e-4289-9bf9-5da8f178536c",
+													"description": "(Required) The workflow execution identifier. Get this value from the response body of the POST operation"
+												}
+											]
+										},
+										"description": "Gets status information about the requested workflow execution. Information includes the time windows of data on which the workflow is executing and the S3 path of the workflow output. Workflow executions are asynchronous invocations of a given reporting workflow, used for testing, development, and on-off reporting use-cases."
+									},
+									"response": [
+										{
+											"name": "Gets status information about the requested workflow execution.",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+													},
+													{
+														"key": "Amazon-Advertising-API-MarketplaceId",
+														"value": "{{marketplace_id}}",
+														"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+													},
+													{
+														"key": "Amazon-Advertising-API-AdvertiserId",
+														"value": "{{advertiser_id}}",
+														"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{api_url}}/amc/reporting/{{instanceId}}/workflowExecutions/:workflowExecutionId?includeWorkflow=false",
+													"host": [
+														"{{api_url}}"
+													],
+													"path": [
+														"amc",
+														"reporting",
+														"{{instanceId}}",
+														"workflowExecutions",
+														":workflowExecutionId"
+													],
+													"query": [
+														{
+															"key": "includeWorkflow",
+															"value": "false",
+															"description": "Optional. If 'true' includes the workflow definition in the response."
+														}
+													],
+													"variable": [
+														{
+															"key": "workflowExecutionId",
+															"value": "b3a77999-7c8e-4289-9bf9-5da8f178536c",
+															"description": "(Required) The workflow execution identifier. Get this value from the response body of the POST operation."
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Wed, 25 Sep 2024 03:14:53 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/vnd.amcworkflowexecutions.v1+json"
+												},
+												{
+													"key": "Content-Length",
+													"value": "1128"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "4F1REDRQ56EMYCVMG63X"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "4F1REDRQ56EMYCVMG63X"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"availableTimeBeforeWindowSecs\": 0,\n    \"createTime\": \"2024-09-25T03:11:52Z\",\n    \"dataGaps\": [],\n    \"disableAggregationControls\": false,\n    \"executionCategory\": \"AD_HOC\",\n    \"executionTime\": 55,\n    \"expireTime\": \"2024-09-26T03:11:52Z\",\n    \"ignoreDataGaps\": false,\n    \"invalidationOffsetSecs\": 266400,\n    \"lastUpdatedTime\": \"2024-09-25T03:14:42Z\",\n    \"outputColumns\": [\n        {\n            \"columnType\": \"DIMENSION\",\n            \"dataType\": \"STRING\",\n            \"name\": \"advertiser\"\n        },\n        {\n            \"columnType\": \"DIMENSION\",\n            \"dataType\": \"STRING\",\n            \"name\": \"campaign\"\n        },\n        {\n            \"columnType\": \"METRIC\",\n            \"dataType\": \"DOUBLE\",\n            \"name\": \"spend\"\n        },\n        {\n            \"columnType\": \"METRIC\",\n            \"dataType\": \"LONG\",\n            \"name\": \"impressions\"\n        },\n        {\n            \"columnType\": \"DIMENSION\",\n            \"dataType\": \"LONG\",\n            \"name\": \"reach\"\n        }\n    ],\n    \"outputS3URI\": \"N/A\",\n    \"parameterValues\": {},\n    \"status\": \"SUCCEEDED\",\n    \"timeWindowEnd\": \"2024-01-25T05:00:00Z\",\n    \"timeWindowEndOriginal\": \"2024-01-25T00:00:00\",\n    \"timeWindowStart\": \"2024-01-20T05:00:00Z\",\n    \"timeWindowStartOriginal\": \"2024-01-20T00:00:00\",\n    \"timeWindowTimeZoneOriginal\": \"America/New_York\",\n    \"validatedTime\": \"2024-09-25T03:11:54.792Z\",\n    \"waitUntil\": \"2024-09-25T02:11:52Z\",\n    \"workflowExecutionId\": \"b3a77999-7c8e-4289-9bf9-5da8f178536c\",\n    \"workflowExecutionTimeoutSeconds\": 21600,\n    \"workflowId\": \"my-first-workflow\"\n}"
+										}
+									]
+								},
+								{
+									"name": "Updates the requested workflow execution.",
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"description": "(Required) The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"disableAggregationControls\": true\n}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{api_url}}/amc/reporting/{{instanceId}}/workflowExecutions/:workflowExecutionId",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"amc",
+												"reporting",
+												"{{instanceId}}",
+												"workflowExecutions",
+												":workflowExecutionId"
+											],
+											"variable": [
+												{
+													"key": "workflowExecutionId",
+													"value": "b3a77999-7c8e-4289-9bf9-5da8f178536c",
+													"description": "(Required) The workflow execution identifier. Get this value from the response body of the POST operation."
+												}
+											]
+										},
+										"description": "Updates the requested workflow execution. Any missing fields will be ignored.\n\nThis operation can be used to update the requested execution's status to CANCELLED if the execution is still pending or running. Updating a FAILED, SUCCEEDED, or CANCELLED execution's status will result in a 400 error response."
+									},
+									"response": []
+								},
+								{
+									"name": "Retrieves pre-signed url for downloading workflow execution results from S3",
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+											},
+											{
+												"key": "Amazon-Advertising-API-MarketplaceId",
+												"value": "{{marketplace_id}}",
+												"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+											},
+											{
+												"key": "Amazon-Advertising-API-AdvertiserId",
+												"value": "{{advertiser_id}}",
+												"description": "(Required)The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/amc/reporting/{{instanceId}}/workflowExecutions/:workflowExecutionId/downloadUrls",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"amc",
+												"reporting",
+												"{{instanceId}}",
+												"workflowExecutions",
+												":workflowExecutionId",
+												"downloadUrls"
+											],
+											"variable": [
+												{
+													"key": "workflowExecutionId",
+													"value": "b3a77999-7c8e-4289-9bf9-5da8f178536c",
+													"description": "(Required) The workflow execution identifier. Get this value from the response body of the POST operation."
+												}
+											]
+										},
+										"description": "Generates and returns pre-signed S3 URLs for the result files produced by and metadata used by the provided workflow execution. If there the results are split into multiple files, then multiple URLs will be returned. URLs expire in 10 minutes and are meant for immediate use and discarding."
+									},
+									"response": [
+										{
+											"name": "Retrieves pre-signed url for downloading workflow execution results from S3",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"description": "(Required) The identifier of a client associated with an Amazon Developer account."
+													},
+													{
+														"key": "Amazon-Advertising-API-MarketplaceId",
+														"value": "{{marketplace_id}}",
+														"description": "(Required) The marketplace identifier for the marketplace in the request. Marketplaces are tied to the country."
+													},
+													{
+														"key": "Amazon-Advertising-API-AdvertiserId",
+														"value": "{{advertiser_id}}",
+														"description": "(Required)The AMC account identifier. Your Amazon Ads account executive would have provided you this identifier when you onboarded AMC. Alternatively, access the AMC console with your user identifier and password, and grab the entity identifier value that is displayed in the URL. The alphanumeric code that is prefixed with ENTITY is your account identifier. An example of an entity identifier is: ENTITY1AA1AA11AAA1."
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{api_url}}/amc/reporting/{{instanceId}}/workflowExecutions/:workflowExecutionId/downloadUrls",
+													"host": [
+														"{{api_url}}"
+													],
+													"path": [
+														"amc",
+														"reporting",
+														"{{instanceId}}",
+														"workflowExecutions",
+														":workflowExecutionId",
+														"downloadUrls"
+													],
+													"variable": [
+														{
+															"key": "workflowExecutionId",
+															"value": "b3a77999-7c8e-4289-9bf9-5da8f178536c",
+															"description": "(Required) The workflow execution identifier. Get this value from the response body of the POST operation."
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Wed, 25 Sep 2024 03:17:56 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/vnd.amcworkflowexecutions.v1+json"
+												},
+												{
+													"key": "Content-Length",
+													"value": "1960"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "SH825DPKKDGAGNNZBW7M"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "SH825DPKKDGAGNNZBW7M"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"downloadUrls\": [\n        \"https://sampleurl\"\n    ],\n    \"metadataDownloadUrls\": [\n        \"https://sampleurl\"\n    ]\n}"
+										}
+									]
+								}
+							]
+						}
+					],
+					"description": "AMC's Workflow Management Service provides you the ability to create, store, and execute parameterized workflows. Workflows can be executed \"on-demand\" or can be scheduled to run at a specific time via AMC's built-in scheduler.\n\nThe following set of APIs help you configure, schedule, and execute your workflows:\n\n- **Workflows**\n    \n- **Schedules**\n    \n- **Workflow executions**"
+				},
+				{
+					"name": "AMC Audiences",
+					"item": [
+						{
+							"name": "Rule-based audiences",
+							"item": [
+								{
+									"name": "Creates query based audience execution metadata information",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) Identifier of a client associated with a 'Login with Amazon' account."
+											},
+											{
+												"key": "Amazon-Advertising-API-EntityId",
+												"value": "{{advertiser_id}}",
+												"description": "Identifier of an entity associated with advertising campaigns. Use `GET` method on amc/accounts to fetch the AMC Account ID/Entity ID."
+											},
+											{
+												"key": "Amazon-Marketing-Cloud-Audience-InstanceId",
+												"value": "{{instanceId}}",
+												"description": "(Required) AMC Instance ID"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"audienceName\": \"AudienceDemo\",\n    \"audienceDescription\": \"Audience created for Audience Demo\",\n    \"advertiserId\": \"11111111\",\n    \"advertiserType\": \"xxxxxx\",\n    \"query\": \"SELECT user_id FROM amazon_attributed_events_by_conversion_time_for_audiences WHERE conversion_event_subtype = 'shoppingCart'\",\n    \"timeWindowStart\": \"2024-05-25T00:00:00Z\",\n    \"timeWindowEnd\": \"2024-05-27T01:00:00Z\",\n    \"refreshRateDays\": 1,\n    \"timeWindowRelative\": \"TRUE\"\n}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": "{{api_url}}/amc/audiences/query",
+										"description": "Creates a query based audience execution metadata. This operation starts the execution workflow to create audience and activate it in DSP. This is an idempotent operation."
+									},
+									"response": [
+										{
+											"name": "Creates query based audience execution metadata information (Sponsored Ads).",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"description": "(Required) Identifier of a client associated with a 'Login with Amazon' account."
+													},
+													{
+														"key": "Amazon-Advertising-API-EntityId",
+														"value": "{{advertiser_id}}",
+														"description": "Identifier of an entity associated with advertising campaigns. Use `GET` method on amc/accounts to fetch the AMC Account ID/Entity ID."
+													},
+													{
+														"key": "Amazon-Marketing-Cloud-Audience-InstanceId",
+														"value": "{{instanceId}}",
+														"description": "(Required) AMC Instance ID"
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n\"audienceName\": \"AudienceDemo\",\n\"audienceDescription\": \"Demo audience created for Sponsored Ad advertisers\",\n\"advertiserId\": \"ENTITY3E2E9XK5B617C\",\n\"advertiserType\": \"SPONSORED_ADS\",\n\"query\": \"SELECT user_id FROM amazon_attributed_events_by_conversion_time_for_audiences WHERE conversion_event_subtype = 'shoppingCart'\",\n\"timeWindowStart\": \"2024-05-25T00:00:00Z\",\n\"timeWindowEnd\": \"2024-05-27T01:00:00Z\",\n\"refreshRateDays\": 1,\n\"timeWindowRelative\": \"TRUE\"\n}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": "{{api_url}}/amc/audiences/query"
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "raw",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Fri, 06 Dec 2024 03:52:48 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/octet-stream"
+												},
+												{
+													"key": "Content-Length",
+													"value": "163"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "9Q3B6Y32R49HHJJWVTDP"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "9Q3B6Y32R49HHJJWVTDP"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\"audienceExecutionDescription\":\"Successfully started audience creation workflow.\",\"audienceExecutionId\":\"7ad8521c-ddd1-42b7-9172-e3b8ad93dc5a\",\"status\":\"PENDING\"}"
+										},
+										{
+											"name": "Creates query based audience execution metadata information (DSP)",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"description": "(Required) Identifier of a client associated with a 'Login with Amazon' account."
+													},
+													{
+														"key": "Amazon-Advertising-API-EntityId",
+														"value": "{{advertiser_id}}",
+														"description": "Identifier of an entity associated with advertising campaigns. Use `GET` method on amc/accounts to fetch the AMC Account ID/Entity ID."
+													},
+													{
+														"key": "Amazon-Marketing-Cloud-Audience-InstanceId",
+														"value": "{{instanceId}}",
+														"description": "(Required) AMC Instance ID"
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n\"audienceName\": \"AudienceDemo\",\n\"audienceDescription\": \"Audience created for Audience Demo\",\n\"advertiserId\": \"580587854428452726\",\n\"advertiserType\": \"DISPLAY\",\n\"query\": \"SELECT user_id FROM amazon_attributed_events_by_conversion_time_for_audiences WHERE conversion_event_subtype = 'shoppingCart'\",\n\"timeWindowStart\": \"2024-05-25T00:00:00Z\",\n\"timeWindowEnd\": \"2024-05-27T01:00:00Z\",\n\"refreshRateDays\": 1,\n\"timeWindowRelative\": \"TRUE\"\n}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": "{{api_url}}/amc/audiences/query"
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "raw",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Fri, 06 Dec 2024 04:08:03 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/octet-stream"
+												},
+												{
+													"key": "Content-Length",
+													"value": "163"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "SZ2QTDWBM2VDQAKT9HKD"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "SZ2QTDWBM2VDQAKT9HKD"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\"audienceExecutionDescription\":\"Successfully started audience creation workflow.\",\"audienceExecutionId\":\"f78827e0-85c4-42b4-8de7-1fe54659331c\",\"status\":\"PENDING\"}"
+										}
+									]
+								},
+								{
+									"name": "Get all query based audiences execution metadata.",
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) Identifier of a client associated with a 'Login with Amazon' account."
+											},
+											{
+												"key": "Amazon-Advertising-API-EntityId",
+												"value": "{{advertiser_id}}",
+												"description": "Identifier of an entity associated with advertising campaigns. Use `GET` method on amc/accounts to fetch the AMC Account ID/Entity ID."
+											},
+											{
+												"key": "Amazon-Marketing-Cloud-Audience-InstanceId",
+												"value": "{{instanceId}}",
+												"description": "(Required) AMC Instance ID"
+											},
+											{
+												"key": "Accept",
+												"value": "application/vnd.amcquerybasedaudience.v1.2+json"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/amc/audiences/query?maxResults=100&nextToken=",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"amc",
+												"audiences",
+												"query"
+											],
+											"query": [
+												{
+													"key": "maxResults",
+													"value": "100",
+													"description": "Optional. Limits the number of items to return in the response. Max value is 100. Defaults to 100."
+												},
+												{
+													"key": "nextToken",
+													"value": "",
+													"description": "Optional. Token to retrieve subsequent page of results."
+												}
+											]
+										},
+										"description": "Returns list of execution metadata information for a given instanceId."
+									},
+									"response": [
+										{
+											"name": "Successfully get all execution metadata for a given instanceId.",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "<string>",
+														"description": "(Required) Identifier of a client associated with a 'Login with Amazon' account."
+													},
+													{
+														"key": "Amazon-Advertising-API-EntityId",
+														"value": "<string>",
+														"description": "Identifier of an entity associated with advertising campaigns. Use `GET` method on amc/accounts to fetch the AMC Account ID/Entity ID."
+													},
+													{
+														"key": "Amazon-Marketing-Cloud-Audience-InstanceId",
+														"value": "<string>",
+														"description": "(Required) AMC Instance ID"
+													},
+													{
+														"key": "Accept",
+														"value": "application/vnd.amcquerybasedaudience.v1.2+json"
+													}
+												],
+												"url": {
+													"raw": "{{api_url}}/amc/audiences/query?maxResults=100&nextToken=<string>",
+													"host": [
+														"{{api_url}}"
+													],
+													"path": [
+														"amc",
+														"audiences",
+														"query"
+													],
+													"query": [
+														{
+															"key": "maxResults",
+															"value": "100",
+															"description": "Optional. Limits the number of items to return in the response. Max value is 100. Defaults to 100."
+														},
+														{
+															"key": "nextToken",
+															"value": "<string>",
+															"description": "Optional. Token to retrieve subsequent page of results."
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/vnd.amcquerybasedaudience.v1.2+json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"executionDataList\": [\n    {\n      \"audienceName\": \"<string>\",\n      \"advertiserId\": \"<string>\",\n      \"query\": \"<string>\",\n      \"instanceId\": \"<string>\",\n      \"timeWindowStart\": \"<dateTime>\",\n      \"timeWindowEnd\": \"<dateTime>\",\n      \"createTime\": \"<dateTime>\",\n      \"lastRefreshedTime\": \"<dateTime>\",\n      \"dspCanonicalId\": \"<string>\",\n      \"inputParameters\": [\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        }\n      ],\n      \"audienceDescription\": \"<string>\",\n      \"dspAudienceId\": \"<string>\",\n      \"refreshRateDays\": \"21\",\n      \"audienceCount\": \"0\",\n      \"timeWindowRelative\": \"false\",\n      \"audienceExecutionId\": \"<string>\",\n      \"audienceType\": \"<string>\",\n      \"no3pTrackers\": \"true\",\n      \"lookalikeAudienceExpectedReach\": \"<string>\",\n      \"advertiserType\": \"DISPLAY\",\n      \"workflowId\": \"<string>\",\n      \"parameterValues\": {},\n      \"status\": \"SUCCEEDED\"\n    },\n    {\n      \"audienceName\": \"<string>\",\n      \"advertiserId\": \"<string>\",\n      \"query\": \"<string>\",\n      \"instanceId\": \"<string>\",\n      \"timeWindowStart\": \"<dateTime>\",\n      \"timeWindowEnd\": \"<dateTime>\",\n      \"createTime\": \"<dateTime>\",\n      \"lastRefreshedTime\": \"<dateTime>\",\n      \"dspCanonicalId\": \"<string>\",\n      \"inputParameters\": [\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        }\n      ],\n      \"audienceDescription\": \"<string>\",\n      \"dspAudienceId\": \"<string>\",\n      \"refreshRateDays\": \"21\",\n      \"audienceCount\": \"0\",\n      \"timeWindowRelative\": \"false\",\n      \"audienceExecutionId\": \"<string>\",\n      \"audienceType\": \"<string>\",\n      \"no3pTrackers\": \"true\",\n      \"lookalikeAudienceExpectedReach\": \"<string>\",\n      \"advertiserType\": \"DISPLAY\",\n      \"workflowId\": \"<string>\",\n      \"parameterValues\": {},\n      \"status\": \"PENDING\"\n    },\n    {\n      \"audienceName\": \"<string>\",\n      \"advertiserId\": \"<string>\",\n      \"query\": \"<string>\",\n      \"instanceId\": \"<string>\",\n      \"timeWindowStart\": \"<dateTime>\",\n      \"timeWindowEnd\": \"<dateTime>\",\n      \"createTime\": \"<dateTime>\",\n      \"lastRefreshedTime\": \"<dateTime>\",\n      \"dspCanonicalId\": \"<string>\",\n      \"inputParameters\": [\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        }\n      ],\n      \"audienceDescription\": \"<string>\",\n      \"dspAudienceId\": \"<string>\",\n      \"refreshRateDays\": \"21\",\n      \"audienceCount\": \"0\",\n      \"timeWindowRelative\": \"false\",\n      \"audienceExecutionId\": \"<string>\",\n      \"audienceType\": \"<string>\",\n      \"no3pTrackers\": \"true\",\n      \"lookalikeAudienceExpectedReach\": \"<string>\",\n      \"advertiserType\": \"DISPLAY\",\n      \"workflowId\": \"<string>\",\n      \"parameterValues\": {},\n      \"status\": \"PENDING\"\n    },\n    {\n      \"audienceName\": \"<string>\",\n      \"advertiserId\": \"<string>\",\n      \"query\": \"<string>\",\n      \"instanceId\": \"<string>\",\n      \"timeWindowStart\": \"<dateTime>\",\n      \"timeWindowEnd\": \"<dateTime>\",\n      \"createTime\": \"<dateTime>\",\n      \"lastRefreshedTime\": \"<dateTime>\",\n      \"dspCanonicalId\": \"<string>\",\n      \"inputParameters\": [\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        }\n      ],\n      \"audienceDescription\": \"<string>\",\n      \"dspAudienceId\": \"<string>\",\n      \"refreshRateDays\": \"21\",\n      \"audienceCount\": \"0\",\n      \"timeWindowRelative\": \"false\",\n      \"audienceExecutionId\": \"<string>\",\n      \"audienceType\": \"<string>\",\n      \"no3pTrackers\": \"true\",\n      \"lookalikeAudienceExpectedReach\": \"<string>\",\n      \"advertiserType\": \"SPONSORED_ADS\",\n      \"workflowId\": \"<string>\",\n      \"parameterValues\": {},\n      \"status\": \"SUCCEEDED\"\n    },\n    {\n      \"audienceName\": \"<string>\",\n      \"advertiserId\": \"<string>\",\n      \"query\": \"<string>\",\n      \"instanceId\": \"<string>\",\n      \"timeWindowStart\": \"<dateTime>\",\n      \"timeWindowEnd\": \"<dateTime>\",\n      \"createTime\": \"<dateTime>\",\n      \"lastRefreshedTime\": \"<dateTime>\",\n      \"dspCanonicalId\": \"<string>\",\n      \"inputParameters\": [\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        }\n      ],\n      \"audienceDescription\": \"<string>\",\n      \"dspAudienceId\": \"<string>\",\n      \"refreshRateDays\": \"21\",\n      \"audienceCount\": \"0\",\n      \"timeWindowRelative\": \"false\",\n      \"audienceExecutionId\": \"<string>\",\n      \"audienceType\": \"<string>\",\n      \"no3pTrackers\": \"true\",\n      \"lookalikeAudienceExpectedReach\": \"<string>\",\n      \"advertiserType\": \"DISPLAY\",\n      \"workflowId\": \"<string>\",\n      \"parameterValues\": {},\n      \"status\": \"SUCCEEDED\"\n    },\n    {\n      \"audienceName\": \"<string>\",\n      \"advertiserId\": \"<string>\",\n      \"query\": \"<string>\",\n      \"instanceId\": \"<string>\",\n      \"timeWindowStart\": \"<dateTime>\",\n      \"timeWindowEnd\": \"<dateTime>\",\n      \"createTime\": \"<dateTime>\",\n      \"lastRefreshedTime\": \"<dateTime>\",\n      \"dspCanonicalId\": \"<string>\",\n      \"inputParameters\": [\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        }\n      ],\n      \"audienceDescription\": \"<string>\",\n      \"dspAudienceId\": \"<string>\",\n      \"refreshRateDays\": \"21\",\n      \"audienceCount\": \"0\",\n      \"timeWindowRelative\": \"false\",\n      \"audienceExecutionId\": \"<string>\",\n      \"audienceType\": \"<string>\",\n      \"no3pTrackers\": \"true\",\n      \"lookalikeAudienceExpectedReach\": \"<string>\",\n      \"advertiserType\": \"SPONSORED_ADS\",\n      \"workflowId\": \"<string>\",\n      \"parameterValues\": {},\n      \"status\": \"DEACTIVATED\"\n    },\n    {\n      \"audienceName\": \"<string>\",\n      \"advertiserId\": \"<string>\",\n      \"query\": \"<string>\",\n      \"instanceId\": \"<string>\",\n      \"timeWindowStart\": \"<dateTime>\",\n      \"timeWindowEnd\": \"<dateTime>\",\n      \"createTime\": \"<dateTime>\",\n      \"lastRefreshedTime\": \"<dateTime>\",\n      \"dspCanonicalId\": \"<string>\",\n      \"inputParameters\": [\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        }\n      ],\n      \"audienceDescription\": \"<string>\",\n      \"dspAudienceId\": \"<string>\",\n      \"refreshRateDays\": \"21\",\n      \"audienceCount\": \"0\",\n      \"timeWindowRelative\": \"false\",\n      \"audienceExecutionId\": \"<string>\",\n      \"audienceType\": \"<string>\",\n      \"no3pTrackers\": \"true\",\n      \"lookalikeAudienceExpectedReach\": \"<string>\",\n      \"advertiserType\": \"SPONSORED_ADS\",\n      \"workflowId\": \"<string>\",\n      \"parameterValues\": {},\n      \"status\": \"SUCCEEDED\"\n    },\n    {\n      \"audienceName\": \"<string>\",\n      \"advertiserId\": \"<string>\",\n      \"query\": \"<string>\",\n      \"instanceId\": \"<string>\",\n      \"timeWindowStart\": \"<dateTime>\",\n      \"timeWindowEnd\": \"<dateTime>\",\n      \"createTime\": \"<dateTime>\",\n      \"lastRefreshedTime\": \"<dateTime>\",\n      \"dspCanonicalId\": \"<string>\",\n      \"inputParameters\": [\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        }\n      ],\n      \"audienceDescription\": \"<string>\",\n      \"dspAudienceId\": \"<string>\",\n      \"refreshRateDays\": \"21\",\n      \"audienceCount\": \"0\",\n      \"timeWindowRelative\": \"false\",\n      \"audienceExecutionId\": \"<string>\",\n      \"audienceType\": \"<string>\",\n      \"no3pTrackers\": \"true\",\n      \"lookalikeAudienceExpectedReach\": \"<string>\",\n      \"advertiserType\": \"SPONSORED_ADS\",\n      \"workflowId\": \"<string>\",\n      \"parameterValues\": {},\n      \"status\": \"RUNNING\"\n    },\n    {\n      \"audienceName\": \"<string>\",\n      \"advertiserId\": \"<string>\",\n      \"query\": \"<string>\",\n      \"instanceId\": \"<string>\",\n      \"timeWindowStart\": \"<dateTime>\",\n      \"timeWindowEnd\": \"<dateTime>\",\n      \"createTime\": \"<dateTime>\",\n      \"lastRefreshedTime\": \"<dateTime>\",\n      \"dspCanonicalId\": \"<string>\",\n      \"inputParameters\": [\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        }\n      ],\n      \"audienceDescription\": \"<string>\",\n      \"dspAudienceId\": \"<string>\",\n      \"refreshRateDays\": \"21\",\n      \"audienceCount\": \"0\",\n      \"timeWindowRelative\": \"false\",\n      \"audienceExecutionId\": \"<string>\",\n      \"audienceType\": \"<string>\",\n      \"no3pTrackers\": \"true\",\n      \"lookalikeAudienceExpectedReach\": \"<string>\",\n      \"advertiserType\": \"SPONSORED_ADS\",\n      \"workflowId\": \"<string>\",\n      \"parameterValues\": {},\n      \"status\": \"SUCCEEDED\"\n    },\n    {\n      \"audienceName\": \"<string>\",\n      \"advertiserId\": \"<string>\",\n      \"query\": \"<string>\",\n      \"instanceId\": \"<string>\",\n      \"timeWindowStart\": \"<dateTime>\",\n      \"timeWindowEnd\": \"<dateTime>\",\n      \"createTime\": \"<dateTime>\",\n      \"lastRefreshedTime\": \"<dateTime>\",\n      \"dspCanonicalId\": \"<string>\",\n      \"inputParameters\": [\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        }\n      ],\n      \"audienceDescription\": \"<string>\",\n      \"dspAudienceId\": \"<string>\",\n      \"refreshRateDays\": \"21\",\n      \"audienceCount\": \"0\",\n      \"timeWindowRelative\": \"false\",\n      \"audienceExecutionId\": \"<string>\",\n      \"audienceType\": \"<string>\",\n      \"no3pTrackers\": \"true\",\n      \"lookalikeAudienceExpectedReach\": \"<string>\",\n      \"advertiserType\": \"DISPLAY\",\n      \"workflowId\": \"<string>\",\n      \"parameterValues\": {},\n      \"status\": \"SUCCEEDED\"\n    },\n    {\n      \"audienceName\": \"<string>\",\n      \"advertiserId\": \"<string>\",\n      \"query\": \"<string>\",\n      \"instanceId\": \"<string>\",\n      \"timeWindowStart\": \"<dateTime>\",\n      \"timeWindowEnd\": \"<dateTime>\",\n      \"createTime\": \"<dateTime>\",\n      \"lastRefreshedTime\": \"<dateTime>\",\n      \"dspCanonicalId\": \"<string>\",\n      \"inputParameters\": [\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        }\n      ],\n      \"audienceDescription\": \"<string>\",\n      \"dspAudienceId\": \"<string>\",\n      \"refreshRateDays\": \"21\",\n      \"audienceCount\": \"0\",\n      \"timeWindowRelative\": \"false\",\n      \"audienceExecutionId\": \"<string>\",\n      \"audienceType\": \"<string>\",\n      \"no3pTrackers\": \"true\",\n      \"lookalikeAudienceExpectedReach\": \"<string>\",\n      \"advertiserType\": \"SPONSORED_ADS\",\n      \"workflowId\": \"<string>\",\n      \"parameterValues\": {},\n      \"status\": \"RUNNING\"\n    },\n    {\n      \"audienceName\": \"<string>\",\n      \"advertiserId\": \"<string>\",\n      \"query\": \"<string>\",\n      \"instanceId\": \"<string>\",\n      \"timeWindowStart\": \"<dateTime>\",\n      \"timeWindowEnd\": \"<dateTime>\",\n      \"createTime\": \"<dateTime>\",\n      \"lastRefreshedTime\": \"<dateTime>\",\n      \"dspCanonicalId\": \"<string>\",\n      \"inputParameters\": [\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        }\n      ],\n      \"audienceDescription\": \"<string>\",\n      \"dspAudienceId\": \"<string>\",\n      \"refreshRateDays\": \"21\",\n      \"audienceCount\": \"0\",\n      \"timeWindowRelative\": \"false\",\n      \"audienceExecutionId\": \"<string>\",\n      \"audienceType\": \"<string>\",\n      \"no3pTrackers\": \"true\",\n      \"lookalikeAudienceExpectedReach\": \"<string>\",\n      \"advertiserType\": \"SPONSORED_ADS\",\n      \"workflowId\": \"<string>\",\n      \"parameterValues\": {},\n      \"status\": \"DEACTIVATED\"\n    },\n    {\n      \"audienceName\": \"<string>\",\n      \"advertiserId\": \"<string>\",\n      \"query\": \"<string>\",\n      \"instanceId\": \"<string>\",\n      \"timeWindowStart\": \"<dateTime>\",\n      \"timeWindowEnd\": \"<dateTime>\",\n      \"createTime\": \"<dateTime>\",\n      \"lastRefreshedTime\": \"<dateTime>\",\n      \"dspCanonicalId\": \"<string>\",\n      \"inputParameters\": [\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        }\n      ],\n      \"audienceDescription\": \"<string>\",\n      \"dspAudienceId\": \"<string>\",\n      \"refreshRateDays\": \"21\",\n      \"audienceCount\": \"0\",\n      \"timeWindowRelative\": \"false\",\n      \"audienceExecutionId\": \"<string>\",\n      \"audienceType\": \"<string>\",\n      \"no3pTrackers\": \"true\",\n      \"lookalikeAudienceExpectedReach\": \"<string>\",\n      \"advertiserType\": \"DISPLAY\",\n      \"workflowId\": \"<string>\",\n      \"parameterValues\": {},\n      \"status\": \"FAILED\"\n    },\n    {\n      \"audienceName\": \"<string>\",\n      \"advertiserId\": \"<string>\",\n      \"query\": \"<string>\",\n      \"instanceId\": \"<string>\",\n      \"timeWindowStart\": \"<dateTime>\",\n      \"timeWindowEnd\": \"<dateTime>\",\n      \"createTime\": \"<dateTime>\",\n      \"lastRefreshedTime\": \"<dateTime>\",\n      \"dspCanonicalId\": \"<string>\",\n      \"inputParameters\": [\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        }\n      ],\n      \"audienceDescription\": \"<string>\",\n      \"dspAudienceId\": \"<string>\",\n      \"refreshRateDays\": \"21\",\n      \"audienceCount\": \"0\",\n      \"timeWindowRelative\": \"false\",\n      \"audienceExecutionId\": \"<string>\",\n      \"audienceType\": \"<string>\",\n      \"no3pTrackers\": \"true\",\n      \"lookalikeAudienceExpectedReach\": \"<string>\",\n      \"advertiserType\": \"DISPLAY\",\n      \"workflowId\": \"<string>\",\n      \"parameterValues\": {},\n      \"status\": \"PENDING\"\n    },\n    {\n      \"audienceName\": \"<string>\",\n      \"advertiserId\": \"<string>\",\n      \"query\": \"<string>\",\n      \"instanceId\": \"<string>\",\n      \"timeWindowStart\": \"<dateTime>\",\n      \"timeWindowEnd\": \"<dateTime>\",\n      \"createTime\": \"<dateTime>\",\n      \"lastRefreshedTime\": \"<dateTime>\",\n      \"dspCanonicalId\": \"<string>\",\n      \"inputParameters\": [\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        }\n      ],\n      \"audienceDescription\": \"<string>\",\n      \"dspAudienceId\": \"<string>\",\n      \"refreshRateDays\": \"21\",\n      \"audienceCount\": \"0\",\n      \"timeWindowRelative\": \"false\",\n      \"audienceExecutionId\": \"<string>\",\n      \"audienceType\": \"<string>\",\n      \"no3pTrackers\": \"true\",\n      \"lookalikeAudienceExpectedReach\": \"<string>\",\n      \"advertiserType\": \"DISPLAY\",\n      \"workflowId\": \"<string>\",\n      \"parameterValues\": {},\n      \"status\": \"FAILED\"\n    },\n    {\n      \"audienceName\": \"<string>\",\n      \"advertiserId\": \"<string>\",\n      \"query\": \"<string>\",\n      \"instanceId\": \"<string>\",\n      \"timeWindowStart\": \"<dateTime>\",\n      \"timeWindowEnd\": \"<dateTime>\",\n      \"createTime\": \"<dateTime>\",\n      \"lastRefreshedTime\": \"<dateTime>\",\n      \"dspCanonicalId\": \"<string>\",\n      \"inputParameters\": [\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        }\n      ],\n      \"audienceDescription\": \"<string>\",\n      \"dspAudienceId\": \"<string>\",\n      \"refreshRateDays\": \"21\",\n      \"audienceCount\": \"0\",\n      \"timeWindowRelative\": \"false\",\n      \"audienceExecutionId\": \"<string>\",\n      \"audienceType\": \"<string>\",\n      \"no3pTrackers\": \"true\",\n      \"lookalikeAudienceExpectedReach\": \"<string>\",\n      \"advertiserType\": \"DISPLAY\",\n      \"workflowId\": \"<string>\",\n      \"parameterValues\": {},\n      \"status\": \"SUCCEEDED\"\n    },\n    {\n      \"audienceName\": \"<string>\",\n      \"advertiserId\": \"<string>\",\n      \"query\": \"<string>\",\n      \"instanceId\": \"<string>\",\n      \"timeWindowStart\": \"<dateTime>\",\n      \"timeWindowEnd\": \"<dateTime>\",\n      \"createTime\": \"<dateTime>\",\n      \"lastRefreshedTime\": \"<dateTime>\",\n      \"dspCanonicalId\": \"<string>\",\n      \"inputParameters\": [\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        }\n      ],\n      \"audienceDescription\": \"<string>\",\n      \"dspAudienceId\": \"<string>\",\n      \"refreshRateDays\": \"21\",\n      \"audienceCount\": \"0\",\n      \"timeWindowRelative\": \"false\",\n      \"audienceExecutionId\": \"<string>\",\n      \"audienceType\": \"<string>\",\n      \"no3pTrackers\": \"true\",\n      \"lookalikeAudienceExpectedReach\": \"<string>\",\n      \"advertiserType\": \"SPONSORED_ADS\",\n      \"workflowId\": \"<string>\",\n      \"parameterValues\": {},\n      \"status\": \"DEACTIVATED\"\n    },\n    {\n      \"audienceName\": \"<string>\",\n      \"advertiserId\": \"<string>\",\n      \"query\": \"<string>\",\n      \"instanceId\": \"<string>\",\n      \"timeWindowStart\": \"<dateTime>\",\n      \"timeWindowEnd\": \"<dateTime>\",\n      \"createTime\": \"<dateTime>\",\n      \"lastRefreshedTime\": \"<dateTime>\",\n      \"dspCanonicalId\": \"<string>\",\n      \"inputParameters\": [\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        }\n      ],\n      \"audienceDescription\": \"<string>\",\n      \"dspAudienceId\": \"<string>\",\n      \"refreshRateDays\": \"21\",\n      \"audienceCount\": \"0\",\n      \"timeWindowRelative\": \"false\",\n      \"audienceExecutionId\": \"<string>\",\n      \"audienceType\": \"<string>\",\n      \"no3pTrackers\": \"true\",\n      \"lookalikeAudienceExpectedReach\": \"<string>\",\n      \"advertiserType\": \"DISPLAY\",\n      \"workflowId\": \"<string>\",\n      \"parameterValues\": {},\n      \"status\": \"DEACTIVATED\"\n    },\n    {\n      \"audienceName\": \"<string>\",\n      \"advertiserId\": \"<string>\",\n      \"query\": \"<string>\",\n      \"instanceId\": \"<string>\",\n      \"timeWindowStart\": \"<dateTime>\",\n      \"timeWindowEnd\": \"<dateTime>\",\n      \"createTime\": \"<dateTime>\",\n      \"lastRefreshedTime\": \"<dateTime>\",\n      \"dspCanonicalId\": \"<string>\",\n      \"inputParameters\": [\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        }\n      ],\n      \"audienceDescription\": \"<string>\",\n      \"dspAudienceId\": \"<string>\",\n      \"refreshRateDays\": \"21\",\n      \"audienceCount\": \"0\",\n      \"timeWindowRelative\": \"false\",\n      \"audienceExecutionId\": \"<string>\",\n      \"audienceType\": \"<string>\",\n      \"no3pTrackers\": \"true\",\n      \"lookalikeAudienceExpectedReach\": \"<string>\",\n      \"advertiserType\": \"SPONSORED_ADS\",\n      \"workflowId\": \"<string>\",\n      \"parameterValues\": {},\n      \"status\": \"DEACTIVATED\"\n    },\n    {\n      \"audienceName\": \"<string>\",\n      \"advertiserId\": \"<string>\",\n      \"query\": \"<string>\",\n      \"instanceId\": \"<string>\",\n      \"timeWindowStart\": \"<dateTime>\",\n      \"timeWindowEnd\": \"<dateTime>\",\n      \"createTime\": \"<dateTime>\",\n      \"lastRefreshedTime\": \"<dateTime>\",\n      \"dspCanonicalId\": \"<string>\",\n      \"inputParameters\": [\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"METRIC\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        },\n        {\n          \"dataType\": \"<string>\",\n          \"name\": \"<string>\",\n          \"columnType\": \"DIMENSION\",\n          \"defaultValue\": \"<string>\",\n          \"description\": \"<string>\"\n        }\n      ],\n      \"audienceDescription\": \"<string>\",\n      \"dspAudienceId\": \"<string>\",\n      \"refreshRateDays\": \"21\",\n      \"audienceCount\": \"0\",\n      \"timeWindowRelative\": \"false\",\n      \"audienceExecutionId\": \"<string>\",\n      \"audienceType\": \"<string>\",\n      \"no3pTrackers\": \"true\",\n      \"lookalikeAudienceExpectedReach\": \"<string>\",\n      \"advertiserType\": \"DISPLAY\",\n      \"workflowId\": \"<string>\",\n      \"parameterValues\": {},\n      \"status\": \"FAILED\"\n    }\n  ],\n  \"nextToken\": \"<string>\"\n}"
+										}
+									]
+								},
+								{
+									"name": "Get query based audience execution metadata for a given audienceExecutionId.",
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) Identifier of a client associated with a 'Login with Amazon' account."
+											},
+											{
+												"key": "Amazon-Advertising-API-EntityId",
+												"value": "{{advertiser_id}}",
+												"description": "Identifier of an entity associated with advertising campaigns. Use `GET` method on amc/accounts to fetch the AMC Account ID/Entity ID."
+											},
+											{
+												"key": "Amazon-Marketing-Cloud-Audience-InstanceId",
+												"value": "{{instanceId}}",
+												"description": "(Required) AMC Instance ID"
+											},
+											{
+												"key": "Accept",
+												"value": "application/vnd.amcquerybasedaudience.v1.2+json"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/amc/audiences/query/:audienceExecutionId",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"amc",
+												"audiences",
+												"query",
+												":audienceExecutionId"
+											],
+											"variable": [
+												{
+													"key": "audienceExecutionId",
+													"value": "2923f36d-6188-4800-8448-a0a4038f23f6",
+													"description": "(Required) Identifier that uniquely represents an AMCQueryBasedAudiencesExecutionMetadata."
+												}
+											]
+										},
+										"description": "Returns execution metadata information for a given instanceId and audienceExecutionId."
+									},
+									"response": [
+										{
+											"name": "Get query based audience execution metadata for a given audienceExecutionId.",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"description": "(Required) Identifier of a client associated with a 'Login with Amazon' account."
+													},
+													{
+														"key": "Amazon-Advertising-API-EntityId",
+														"value": "{{advertiser_id}}",
+														"description": "Identifier of an entity associated with advertising campaigns. Use `GET` method on amc/accounts to fetch the AMC Account ID/Entity ID."
+													},
+													{
+														"key": "Amazon-Marketing-Cloud-Audience-InstanceId",
+														"value": "{{instanceId}}",
+														"description": "(Required) AMC Instance ID"
+													},
+													{
+														"key": "Accept",
+														"value": "application/vnd.amcquerybasedaudience.v1.2+json"
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{api_url}}/amc/audiences/query/:audienceExecutionId",
+													"host": [
+														"{{api_url}}"
+													],
+													"path": [
+														"amc",
+														"audiences",
+														"query",
+														":audienceExecutionId"
+													],
+													"variable": [
+														{
+															"key": "audienceExecutionId",
+															"value": "2923f36d-6188-4800-8448-a0a4038f23f6",
+															"description": "(Required) Identifier that uniquely represents an AMCQueryBasedAudiencesExecutionMetadata."
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Wed, 25 Sep 2024 17:45:22 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/vnd.amcquerybasedaudience.v1.2+json"
+												},
+												{
+													"key": "Content-Length",
+													"value": "589"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "4MW4SFX67G4XDC81E6D4"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "4MW4SFX67G4XDC81E6D4"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"advertiserId\": \"9708102980201\",\n    \"advertiserType\": \"DISPLAY\",\n    \"audienceDescription\": \"Audience created for Audience Demo\",\n    \"audienceExecutionId\": \"2923f36d-6188-4800-8448-a0a4038f23f6\",\n    \"audienceName\": \"AMC AudienceDemo\",\n    \"audienceType\": \"RULE_BASED\",\n    \"createTime\": \"2024-09-25T17:43:34.808Z\",\n    \"instanceId\": \"amc3dbuhjvh\",\n    \"query\": \"SELECT user_id FROM amazon_attributed_events_by_conversion_time_for_audiences WHERE conversion_event_subtype = 'shoppingCart'\",\n    \"refreshRateDays\": 1,\n    \"status\": \"RUNNING\",\n    \"timeWindowEnd\": \"2022-05-27T01:00:00Z\",\n    \"timeWindowRelative\": true,\n    \"timeWindowStart\": \"2022-05-25T00:00:00Z\"\n}"
+										}
+									]
+								},
+								{
+									"name": "Update query based audience execution metadata for a given audienceExecutionId.",
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) Identifier of a client associated with a 'Login with Amazon' account."
+											},
+											{
+												"key": "Amazon-Advertising-API-EntityId",
+												"value": "{{advertiser_id}}",
+												"description": "Identifier of an entity associated with advertising campaigns. Use `GET` method on amc/accounts to fetch the AMC Account ID/Entity ID."
+											},
+											{
+												"key": "Amazon-Marketing-Cloud-Audience-InstanceId",
+												"value": "{{instanceId}}",
+												"description": "(Required) AMC Instance ID"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"query\": true\n}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{api_url}}/amc/audiences/query/:audienceExecutionId",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"amc",
+												"audiences",
+												"query",
+												":audienceExecutionId"
+											],
+											"variable": [
+												{
+													"key": "audienceExecutionId",
+													"value": "2923f36d-6188-4800-8448-a0a4038f23f6",
+													"description": "(Required) Identifier that uniquely represents an AMCQueryBasedAudiencesExecutionMetadata."
+												}
+											]
+										},
+										"description": "Updates audience configuration for a given audienceExecutionId. This will replace the configuration of the audience, resetting any non-provided attributes to default values. Only FAILED audiences may be updated at this time."
+									},
+									"response": [
+										{
+											"name": "Update audience metadata received from process.",
+											"originalRequest": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "<string>",
+														"description": "(Required) Identifier of a client associated with a 'Login with Amazon' account."
+													},
+													{
+														"key": "Amazon-Advertising-API-EntityId",
+														"value": "<string>",
+														"description": "Identifier of an entity associated with advertising campaigns. Use `GET` method on amc/accounts to fetch the AMC Account ID/Entity ID."
+													},
+													{
+														"key": "Amazon-Marketing-Cloud-Audience-InstanceId",
+														"value": "<string>",
+														"description": "(Required) AMC Instance ID"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.amcquerybasedaudience.v1+json"
+													},
+													{
+														"key": "Accept",
+														"value": "application/vnd.amcquerybasedaudience.v1.2+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"query\": true\n}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{api_url}}/amc/audiences/query/:audienceExecutionId",
+													"host": [
+														"{{api_url}}"
+													],
+													"path": [
+														"amc",
+														"audiences",
+														"query",
+														":audienceExecutionId"
+													],
+													"variable": [
+														{
+															"key": "audienceExecutionId",
+															"value": ""
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/vnd.amcquerybasedaudience.v1.2+json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"audienceExecutionId\": \"<string>\",\n  \"status\": \"DEACTIVATED\",\n  \"audienceExecutionDescription\": \"<string>\"\n}"
+										}
+									]
+								},
+								{
+									"name": "Delete query based audience execution metadata for a given audienceExecutionId.",
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) Identifier of a client associated with a 'Login with Amazon' account."
+											},
+											{
+												"key": "Amazon-Advertising-API-EntityId",
+												"value": "{{advertiser_id}}",
+												"description": "Identifier of an entity associated with advertising campaigns. Use `GET` method on amc/accounts to fetch the AMC Account ID/Entity ID."
+											},
+											{
+												"key": "Amazon-Marketing-Cloud-Audience-InstanceId",
+												"value": "{{instanceId}}",
+												"description": "(Required) AMC Instance ID"
+											},
+											{
+												"key": "Accept",
+												"value": "application/vnd.amcquerybasedaudience.v1+json"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{api_url}}/amc/audiences/query/:audienceExecutionId",
+											"host": [
+												"{{api_url}}"
+											],
+											"path": [
+												"amc",
+												"audiences",
+												"query",
+												":audienceExecutionId"
+											],
+											"variable": [
+												{
+													"key": "audienceExecutionId",
+													"value": ""
+												}
+											]
+										},
+										"description": "Deletes an audience for a given instanceId and audienceExecutionId. Only FAILED audiences may be deleted at this time."
+									},
+									"response": [
+										{
+											"name": "Successfully deleted audience with given audienceExecutionId.",
+											"originalRequest": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "<string>",
+														"description": "(Required) Identifier of a client associated with a 'Login with Amazon' account."
+													},
+													{
+														"key": "Amazon-Advertising-API-EntityId",
+														"value": "<string>",
+														"description": "Identifier of an entity associated with advertising campaigns. Use `GET` method on amc/accounts to fetch the AMC Account ID/Entity ID."
+													},
+													{
+														"key": "Amazon-Marketing-Cloud-Audience-InstanceId",
+														"value": "<string>",
+														"description": "(Required) AMC Instance ID"
+													}
+												],
+												"url": {
+													"raw": "{{api_url}}/amc/audiences/query/:audienceExecutionId",
+													"host": [
+														"{{api_url}}"
+													],
+													"path": [
+														"amc",
+														"audiences",
+														"query",
+														":audienceExecutionId"
+													],
+													"variable": [
+														{
+															"key": "audienceExecutionId",
+															"value": ""
+														}
+													]
+												}
+											},
+											"status": "No Content",
+											"code": 204,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": [],
+											"body": ""
+										}
+									]
+								}
+							]
+						},
+						{
+							"name": "Lookalike audiences",
+							"item": [
+								{
+									"name": "Creates lookalike audience execution metadata information.",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Amazon-Advertising-API-ClientId",
+												"value": "{{client_id}}",
+												"description": "(Required) Identifier of a client associated with a 'Login with Amazon' account."
+											},
+											{
+												"key": "Amazon-Advertising-API-EntityId",
+												"value": "{{advertiser_id}}",
+												"description": "Identifier of an entity associated with advertising campaigns. Use `GET` method on amc/accounts to fetch the AMC Account ID/Entity ID."
+											},
+											{
+												"key": "Amazon-Marketing-Cloud-Audience-InstanceId",
+												"value": "{{instanceId}}",
+												"description": "(Required) AMC Instance ID"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{access_token}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"audienceName\": \"NewName\",\n  \"audienceDescription\": \"NEWNEW\",\n  \"timeWindowStart\": \"2024-06-01T14:15:22Z\",\n  \"timeWindowEnd\": \"2024-07-01T14:15:22Z\",\n  \"query\": \"SELECT user_id FROM sponsored_ads_traffic_for_audiences WHERE customer_search_term SIMILAR TO '(?i)chai'\",\n  \"refreshRateDays\": 7,\n  \"timeWindowRelative\": \"true\",\n  \"advertiserId\": \"5934073340501\",\n  \"lookalikeAudienceExpectedReach\": \"SIMILAR\"\n}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": "{{api_url}}/amc/audiences/lookalike",
+										"description": "Creates a lookalike audience execution metadata. This operation starts the execution workflow to generate lookalike audience and activate it in DSP. This is an idempotent operation."
+									},
+									"response": [
+										{
+											"name": "Creates lookalike audience execution metadata information.",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Amazon-Advertising-API-ClientId",
+														"value": "{{client_id}}",
+														"description": "(Required) Identifier of a client associated with a 'Login with Amazon' account."
+													},
+													{
+														"key": "Amazon-Advertising-API-EntityId",
+														"value": "{{advertiser_id}}",
+														"description": "Identifier of an entity associated with advertising campaigns. Use `GET` method on amc/accounts to fetch the AMC Account ID/Entity ID."
+													},
+													{
+														"key": "Amazon-Marketing-Cloud-Audience-InstanceId",
+														"value": "{{instanceId}}",
+														"description": "(Required) AMC Instance ID"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.amcquerybasedaudience.v1+json",
+														"disabled": true
+													},
+													{
+														"key": "Accept",
+														"value": "application/vnd.amclookalikeaudience.v1+json",
+														"disabled": true
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"audienceName\": \"FirstLookAlikeAudience\",\n  \"audienceDescription\": \"Lookalike audience with Sponsored Ads Traffic data\",\n  \"timeWindowStart\": \"2024-06-01T14:15:22Z\",\n  \"timeWindowEnd\": \"2024-07-01T14:15:22Z\",\n  \"query\": \"SELECT user_id FROM sponsored_ads_traffic_for_audiences WHERE customer_search_term SIMILAR TO '(?i)chai'\",\n  \"refreshRateDays\": 7,\n  \"timeWindowRelative\": \"true\",\n  \"advertiserId\": \"5934073340501\",\n  \"lookalikeAudienceExpectedReach\": \"SIMILAR\"\n}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": "{{api_url}}/amc/audiences/lookalike"
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Server",
+													"value": "Server"
+												},
+												{
+													"key": "Date",
+													"value": "Wed, 25 Sep 2024 20:16:13 GMT"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json",
+													"description": "",
+													"type": "text"
+												},
+												{
+													"key": "Content-Length",
+													"value": "163"
+												},
+												{
+													"key": "Connection",
+													"value": "keep-alive"
+												},
+												{
+													"key": "x-amz-rid",
+													"value": "MVKTPTDHNV00N5EFPMQP"
+												},
+												{
+													"key": "x-amz-request-id",
+													"value": "MVKTPTDHNV00N5EFPMQP"
+												},
+												{
+													"key": "Vary",
+													"value": "Content-Type,Accept-Encoding,User-Agent"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=47474747; includeSubDomains; preload"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"audienceExecutionDescription\": \"Successfully started audience creation workflow.\",\n    \"audienceExecutionId\": \"f04fe81e-b641-4201-a300-c37ee0fb44b8\",\n    \"status\": \"PENDING\"\n}"
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		{
 			"name": "Sponsored Products",
 			"item": [
 				{


### PR DESCRIPTION
*Description of changes:*

Adds Amazon Marketing Cloud Calls to the Amazon Ads API Postman collection.

Folder structure for additions:
```
└── Amazon Marketing Cloud
    ├── Administration
    │   ├── Accounts
    |   └── Instances
    ├── Reporting
    │   ├── Workflows
    │   ├── Schedules
    |   └── Workflow executions
    └── AMC Audiences
        ├── Rule-based audiences
        └── Lookalike audiences
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
