### PR TITLE
Add amazon-ads-mcp-workshop-non-aws: Building an AI agent capable of managing Amazon Ads campaigns using the Model Context Protocol (MCP) and Claude via the Anthropic API, with no AWS account required

### DIFF
--- a/amazon-ads-mcp-workshop-non-aws/01-overview-and-setup.md
+++ b/amazon-ads-mcp-workshop-non-aws/01-overview-and-setup.md
@@ -1,0 +1,211 @@
+---
+title: "Module 1: Overview and Setup"
+description: Workshop overview, prerequisites, and environment setup for building an Amazon Ads agent using the Anthropic API and the Amazon Ads MCP Server.
+---
+
+# Module 1: Overview and Setup
+
+>[NOTE] Set up your development environment and verify all prerequisites before building your Amazon Ads agent.
+
+---
+
+## Workshop Overview
+
+This workshop walks you through connecting to the Amazon Ads MCP Server and building a LangGraph agent powered by Claude via the Anthropic API. No AWS account is required — everything runs locally on your machine.
+
+By the end of this workshop you will have:
+
+- Connected to the Amazon Ads MCP Server via Streamable HTTP
+- Discovered and explored available advertising tools
+- Built a LangGraph agent that orchestrates Amazon Ads API calls using Claude
+- Tested the agent with account discovery and campaign management prompts
+
+### Target Audience
+
+Solutions architects, software engineers, and technical leads who work with the Amazon Ads API and want to build AI-powered automation using MCP — without requiring an AWS account.
+
+---
+
+## Contributors
+
+This workshop was created by [Chintan Sanghavi](https://www.linkedin.com/in/chintansanghavi/) and [Christelle Ngambula](https://www.linkedin.com/in/chrisngambula/), both Senior Solutions Architects at Amazon Ads. For questions or additional details, connect with either contributor via LinkedIn.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────┐
+│    User Prompt       │
+└──────────┬──────────┘
+           │
+           ▼
+┌─────────────────────┐
+│   LangGraph Agent    │
+│   (runs locally)     │
+└──────────┬──────────┘
+           │
+     ┌─────┴──────┐
+     │             │
+     ▼             ▼
+┌──────────┐  ┌──────────────┐
+│ Anthropic│  │  Amazon Ads  │
+│   API    │  │  MCP Server  │
+│ (Claude) │  │(Streamable HTTP)│
+└──────────┘  └──────┬───────┘
+                     │
+                     ▼
+              ┌──────────────┐
+              │  Amazon Ads  │
+              │     API      │
+              └──────────────┘
+```
+
+---
+
+## Step 1: Verify Prerequisites
+
+| Prerequisite | Details |
+|---|---|
+| **Python 3.13+** | Verify with `python --version`. |
+| **pip** | Python package manager. Ships with Python 3.13+. |
+| **Anthropic API Key** | Obtain from [console.anthropic.com](https://console.anthropic.com/). |
+| **Amazon Ads API Client ID** | Obtain from the [Amazon Ads developer console](https://advertising.amazon.com/API/docs/en-us/get-started/overview). |
+| **Amazon Ads API Client Secret** | Obtain from the Amazon Ads developer console. |
+| **Amazon Ads API Refresh Token** | Generated during the OAuth flow for your Ads API application. |
+
+>[NOTE] This workshop is designed for Linux and macOS environments. If you are on Windows, we recommend using Windows Subsystem for Linux (WSL) to follow along.
+
+---
+
+## Step 2: Create a Virtual Environment
+
+```bash
+mkdir workshop-ads-agent
+cd workshop-ads-agent
+python -m venv .venv
+```
+
+Activate the virtual environment:
+
+```bash
+# macOS / Linux
+source .venv/bin/activate
+
+# Windows (PowerShell)
+.venv\Scripts\Activate.ps1
+```
+
+You should see `(.venv)` in your terminal prompt.
+
+---
+
+## Step 3: Install Dependencies
+
+Create a `requirements.txt`:
+
+```text
+langchain
+langchain-core
+langchain-anthropic
+langgraph
+langchain-mcp-adapters
+pydantic
+python-dotenv
+requests
+```
+
+Install:
+
+```bash
+pip install -r requirements.txt
+```
+
+---
+
+## Step 4: Configure Environment Variables
+
+Create a `.env` file:
+
+```bash
+# Anthropic
+ANTHROPIC_API_KEY=<YOUR_ANTHROPIC_API_KEY>
+
+# Amazon Ads
+CLIENT_ID=<YOUR_AMAZON_ADS_CLIENT_ID>
+CLIENT_SECRET=<YOUR_AMAZON_ADS_CLIENT_SECRET>
+REFRESH_TOKEN=<YOUR_AMAZON_ADS_REFRESH_TOKEN>
+
+# Optional: filter which tool groups to load
+TOOL_FILTER=account_management,campaign_management,reporting
+```
+
+>[NOTE] Never commit your `.env` file to version control. Add `.env` to your `.gitignore`.
+
+---
+
+## Step 5: Verify Your Setup
+
+Create a file called `verify_setup.py`:
+
+```python
+"""Verify workshop environment setup."""
+import sys
+
+checks = []
+
+v = sys.version_info
+checks.append(("Python 3.13+", v.major == 3 and v.minor >= 13))
+
+for pkg in ["langchain", "langgraph", "langchain_anthropic", "langchain_mcp_adapters", "pydantic", "dotenv", "requests"]:
+    try:
+        __import__(pkg)
+        checks.append((f"Package: {pkg}", True))
+    except ImportError:
+        checks.append((f"Package: {pkg}", False))
+
+import os
+from dotenv import load_dotenv
+load_dotenv()
+for var in ["ANTHROPIC_API_KEY", "CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"]:
+    checks.append((f"Env: {var}", bool(os.getenv(var))))
+
+print("\n=== Workshop Environment Check ===\n")
+all_pass = True
+for name, passed in checks:
+    icon = "[OK]" if passed else "[!!]"
+    print(f"  {icon} {name}: {'PASS' if passed else 'FAIL'}")
+    if not passed:
+        all_pass = False
+
+print()
+if all_pass:
+    print("All checks passed. You are ready for the workshop!")
+else:
+    print("Some checks failed. Please fix the missing items before proceeding.")
+```
+
+Run it:
+
+```bash
+python verify_setup.py
+```
+
+All checks should show `[OK]`.
+
+---
+
+## Module Listing
+
+| Module | Title | Time |
+|---|---|---|
+| 01 | Overview and Setup (this module) | 15 min |
+| 02 | Connect to Amazon Ads MCP Server | 20 min |
+| 03 | Build an Ads Agent | 45 min |
+| 04 | Testing and Cleanup | 20 min |
+
+**Total estimated time: ~1.5 hours**
+
+---
+
+[Next: Connect to Amazon Ads MCP Server →](02-connect-ads-mcp-server.md)

--- a/amazon-ads-mcp-workshop-non-aws/02-connect-ads-mcp-server.md
+++ b/amazon-ads-mcp-workshop-non-aws/02-connect-ads-mcp-server.md
@@ -1,0 +1,189 @@
+---
+title: "Module 2: Connect to Amazon Ads MCP Server"
+description: Obtain an OAuth access token, connect to the Amazon Ads MCP Server via Streamable HTTP, and discover available tools.
+---
+
+# Module 2: Connect to Amazon Ads MCP Server
+
+>[NOTE] Exchange your credentials for an access token, connect to the Amazon Ads MCP Server, and explore the available tools.
+
+## When to Use
+
+- You have completed Module 1 and your environment is set up
+- You have Amazon Ads API credentials (Client ID, Client Secret, Refresh Token)
+
+---
+
+## Step 1: Understand the Connection Flow
+
+The Amazon Ads MCP Server is a remote endpoint you connect to via Streamable HTTP. The connection requires an OAuth access token obtained by exchanging your Refresh Token.
+
+```
+Your Code
+    │
+    ├── 1. Exchange Refresh Token for Access Token
+    │       POST https://api.amazon.com/auth/o2/token
+    │       → Returns short-lived Access Token
+    │
+    ├── 2. Connect to Ads MCP Server via Streamable HTTP
+    │       https://advertising-ai.amazon.com/mcp
+    │       Headers: Authorization, Amazon-Ads-ClientId
+    │
+    └── 3. Discover tools via tools/list
+            → Returns available advertising tools
+```
+
+### MCP Server URLs by Region
+
+| Region | Endpoint URL |
+|--------|-------------|
+| NA (North America) | `https://advertising-ai.amazon.com/mcp` |
+| EU (Europe) | `https://advertising-ai-eu.amazon.com/mcp` |
+| FE (Far East) | `https://advertising-ai-fe.amazon.com/mcp` |
+
+---
+
+## Step 2: Test the OAuth Token Exchange
+
+Create a file called `test_connection.py` to verify your credentials work:
+
+```python
+"""Test OAuth token exchange and Ads MCP Server connection."""
+
+import os
+import asyncio
+import requests
+from dotenv import load_dotenv
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+load_dotenv()
+
+CLIENT_ID = os.getenv("CLIENT_ID")
+CLIENT_SECRET = os.getenv("CLIENT_SECRET")
+REFRESH_TOKEN = os.getenv("REFRESH_TOKEN")
+
+
+def get_access_token() -> str:
+    """Exchange refresh token for a short-lived access token."""
+    response = requests.post(
+        "https://api.amazon.com/auth/o2/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": REFRESH_TOKEN,
+            "client_id": CLIENT_ID,
+            "client_secret": CLIENT_SECRET,
+        },
+    )
+    if response.status_code != 200:
+        print(f"OAuth failed: {response.status_code} - {response.text[:200]}")
+        return ""
+    print("Access token obtained successfully")
+    return response.json()["access_token"]
+
+
+async def discover_tools():
+    """Connect to the Ads MCP Server and list available tools."""
+    access_token = get_access_token()
+    if not access_token:
+        return
+
+    client = MultiServerMCPClient(
+        {
+            "amzn-ads": {
+                "url": "https://advertising-ai.amazon.com/mcp",
+                "transport": "streamable_http",
+                "headers": {
+                    "Authorization": access_token,
+                    "Amazon-Ads-ClientId": CLIENT_ID,
+                    "Accept": "application/json, text/event-stream",
+                },
+            }
+        }
+    )
+
+    tools = await client.get_tools()
+    print(f"\nDiscovered {len(tools)} tools:\n")
+    for tool in tools:
+        print(f"  - {tool.name}")
+
+    return tools
+
+
+if __name__ == "__main__":
+    asyncio.run(discover_tools())
+```
+
+Run it:
+
+```bash
+python test_connection.py
+```
+
+You should see a list of 50+ tools. If you get a 403 error, verify:
+- Your Client ID, Client Secret, and Refresh Token are correct
+- The `Authorization` header contains the raw access token (no `Bearer` prefix)
+- Your application has the correct scopes in the Amazon Ads developer console
+
+>[NOTE] The `Authorization` header must contain the raw access token, not `Bearer <token>`. This is a common source of 403 errors.
+
+---
+
+## Step 3: Understand the Tool Naming Convention
+
+Amazon Ads MCP Server tools follow a `<tool_group>-<tool_name>` pattern:
+
+| Tool Group | Description | Example Tools |
+|---|---|---|
+| **account_management** | Manage advertiser accounts and profiles | `account_management-list_profiles` |
+| **campaign_management** | Create, update, and manage campaigns | `campaign_management-create_campaign`, `campaign_management-list_campaigns` |
+| **reporting** | Generate performance reports | `reporting-get_campaign_report` |
+| **locale_expansion** | Marketplace expansion recommendations | `locale_expansion-get_locale_recommendations` |
+
+### Account Identification Parameters
+
+Many tools require account identifiers:
+
+| Parameter | Description |
+|---|---|
+| `profileId` | Identifies an Amazon Ads profile for a specific marketplace. Obtain via `account_management-list_profiles`. |
+| `advertiserAccountId` | Identifies a specific advertiser account. |
+| `managerAccountId` | Identifies the manager (agency) account. |
+
+Typical workflow: call `query_advertiser_accounts` first to discover accounts, then use the returned identifiers in subsequent calls.
+
+---
+
+## Step 4: Filter Tools (Optional)
+
+The Ads MCP Server exposes 50+ tools. You can filter to only the groups you need using the `TOOL_FILTER` environment variable you set in Module 1.
+
+```python
+tool_filter = os.getenv("TOOL_FILTER", "")
+allowed_groups = [g.strip() for g in tool_filter.split(",") if g.strip()]
+
+if allowed_groups:
+    filtered_tools = [
+        t for t in all_tools
+        if any(t.name.startswith(g) for g in allowed_groups)
+    ]
+    print(f"Filtered to {len(filtered_tools)} tools from groups: {allowed_groups}")
+else:
+    filtered_tools = all_tools
+```
+
+>[TIP] Filtering tools reduces the token count in Claude's context window and improves response quality. Start with `account_management,campaign_management,reporting` and expand as needed.
+
+---
+
+## Summary
+
+You have:
+1. Exchanged your Refresh Token for an access token via the Amazon OAuth endpoint
+2. Connected to the Amazon Ads MCP Server via Streamable HTTP
+3. Discovered available tools and understood the naming convention
+
+In the next module, you will build a LangGraph agent that uses these tools with Claude via the Anthropic API.
+
+---
+
+[← Previous: Overview and Setup](01-overview-and-setup.md) | [Next: Build an Ads Agent →](03-build-ads-agent.md)

--- a/amazon-ads-mcp-workshop-non-aws/03-build-ads-agent.md
+++ b/amazon-ads-mcp-workshop-non-aws/03-build-ads-agent.md
@@ -1,0 +1,306 @@
+---
+title: "Module 3: Build an Ads Agent"
+description: Build a LangGraph agent that connects to the Amazon Ads MCP Server and uses Claude via the Anthropic API to orchestrate advertising workflows.
+---
+
+# Module 3: Build an Ads Agent
+
+>[NOTE] Build a LangGraph agent powered by Claude (via Anthropic API) that discovers and invokes Amazon Ads MCP Server tools to manage advertising campaigns.
+
+## When to Use
+
+- You have completed Module 2 and can connect to the Amazon Ads MCP Server
+- You want to build an agent that orchestrates Ads API calls using natural language
+
+---
+
+## Step 1: Understand the Agent Architecture
+
+```
+┌─────────────────────┐
+│    User Prompt       │
+└──────────┬──────────┘
+           │
+           ▼
+┌─────────────────────┐
+│   LangGraph Agent    │
+│                      │
+│  ┌───────────────┐   │
+│  │ Claude (LLM)  │   │     Streamable HTTP (MCP)
+│  │ via Anthropic │   │────────────────────────────┐
+│  │    API        │   │                            │
+│  └───────────────┘   │                            ▼
+└──────────────────────┘                   ┌──────────────┐
+                                           │  Amazon Ads  │
+                                           │  MCP Server  │
+                                           └──────┬───────┘
+                                                  │
+                                                  ▼
+                                           ┌──────────────┐
+                                           │  Amazon Ads  │
+                                           │     API      │
+                                           └──────────────┘
+```
+
+The agent:
+1. Receives a natural language prompt from the user
+2. Uses Claude to decide which Ads MCP tools to call
+3. Executes tool calls against the Amazon Ads MCP Server
+4. Returns a natural language response
+
+---
+
+## Step 2: Create the Agent
+
+Create a file named `ads_agent.py`:
+
+```python
+"""
+Amazon Ads Agent — LangGraph + Anthropic API + Amazon Ads MCP Server
+
+Connects to the Amazon Ads MCP Server via Streamable HTTP,
+discovers tools, and orchestrates advertising workflows
+using Claude via the Anthropic API.
+"""
+
+import os
+import sys
+import asyncio
+import requests
+from datetime import datetime
+from dotenv import load_dotenv
+from langchain_anthropic import ChatAnthropic
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langgraph.prebuilt import create_react_agent
+
+load_dotenv()
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+CLIENT_ID = os.getenv("CLIENT_ID")
+CLIENT_SECRET = os.getenv("CLIENT_SECRET")
+REFRESH_TOKEN = os.getenv("REFRESH_TOKEN")
+ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
+TOOL_FILTER = os.getenv("TOOL_FILTER", "")
+
+
+def log_info(msg):
+    print(f"[INFO] {datetime.now().isoformat()} - {msg}", flush=True)
+
+
+def log_error(msg):
+    print(f"[ERROR] {datetime.now().isoformat()} - {msg}", file=sys.stderr, flush=True)
+
+
+# ============================================================================
+# OAuth Access Token
+# ============================================================================
+
+def get_access_token() -> str:
+    """Exchange refresh token for a short-lived access token."""
+    log_info("Requesting OAuth access token...")
+    response = requests.post(
+        "https://api.amazon.com/auth/o2/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": REFRESH_TOKEN,
+            "client_id": CLIENT_ID,
+            "client_secret": CLIENT_SECRET,
+        },
+    )
+    if response.status_code != 200:
+        log_error(f"OAuth failed: {response.status_code} - {response.text[:200]}")
+        sys.exit(1)
+    log_info("Access token obtained")
+    return response.json()["access_token"]
+
+
+# ============================================================================
+# Agent Builder
+# ============================================================================
+
+async def build_agent():
+    """Connect to Ads MCP Server, discover tools, and create the agent."""
+
+    # 1. Get access token
+    access_token = get_access_token()
+
+    # 2. Connect to Ads MCP Server
+    log_info("Connecting to Amazon Ads MCP Server...")
+    mcp_client = MultiServerMCPClient(
+        {
+            "amzn-ads": {
+                "url": "https://advertising-ai.amazon.com/mcp",
+                "transport": "streamable_http",
+                "headers": {
+                    "Authorization": access_token,
+                    "Amazon-Ads-ClientId": CLIENT_ID,
+                    "Accept": "application/json, text/event-stream",
+                },
+            }
+        }
+    )
+
+    # 3. Discover tools (with retry for rate limiting)
+    import time
+    for attempt in range(3):
+        try:
+            tools = await mcp_client.get_tools()
+            log_info(f"Discovered {len(tools)} tools")
+            break
+        except Exception as e:
+            if "429" in str(e) and attempt < 2:
+                wait = (attempt + 1) * 10
+                log_info(f"Rate limited. Retrying in {wait}s...")
+                time.sleep(wait)
+            else:
+                raise
+
+    # 4. Filter tools (optional)
+    allowed_groups = [g.strip() for g in TOOL_FILTER.split(",") if g.strip()]
+    if allowed_groups:
+        tools = [t for t in tools if any(t.name.startswith(g) for g in allowed_groups)]
+        log_info(f"Filtered to {len(tools)} tools from groups: {allowed_groups}")
+
+    for t in tools:
+        log_info(f"  Tool: {t.name}")
+
+    # 5. Initialize Claude via Anthropic API
+    llm = ChatAnthropic(
+        model="claude-sonnet-4-20250514",
+        api_key=ANTHROPIC_API_KEY,
+        temperature=0.1,
+        max_tokens=2048,
+    )
+
+    # 6. Create the ReAct agent
+    system_prompt = (
+        "You are an Amazon Ads Campaign Assistant with access to the Amazon Ads API.\n\n"
+        "## Your Capabilities\n"
+        "- Query advertiser accounts and profiles\n"
+        "- View, create, and manage campaigns\n"
+        "- Request performance reports\n\n"
+        "## Campaign Creation Workflow\n"
+        "1. Call query_advertiser_accounts to identify available accounts.\n"
+        "2. Ask the user which account/profile to use if not already known.\n"
+        "3. Gather missing details: campaign name, budget, start date, targeting type.\n"
+        "4. Confirm details with the user before creating.\n"
+        "5. Call the appropriate campaign creation tool.\n"
+        "6. Verify the campaign was created successfully.\n\n"
+        "## Important Rules\n"
+        "- Always confirm campaign details before executing creation or modification.\n"
+        "- Default to Sponsored Products and manual targeting unless specified.\n"
+        "- Budget must be at least $1.00. Start date must be YYYY-MM-DD format.\n"
+    )
+
+    agent = create_react_agent(llm, tools, prompt=system_prompt)
+    log_info("Agent ready")
+    return agent
+```
+
+---
+
+## Step 3: Add the Interactive Loop
+
+Add the interactive chat loop at the bottom of `ads_agent.py`:
+
+```python
+# ============================================================================
+# Interactive Chat
+# ============================================================================
+
+async def chat(agent):
+    """Run an interactive chat loop with the agent."""
+    print("\n" + "=" * 60)
+    print("Amazon Ads Agent — Interactive Mode")
+    print("Type 'quit' to exit")
+    print("=" * 60 + "\n")
+
+    while True:
+        try:
+            user_input = input("You: ").strip()
+            if not user_input:
+                continue
+            if user_input.lower() in ("quit", "exit", "q"):
+                print("Goodbye!")
+                break
+
+            response = await agent.ainvoke(
+                {"messages": [{"role": "user", "content": user_input}]}
+            )
+            reply = response["messages"][-1].content
+            print(f"\nAgent: {reply}\n")
+
+        except KeyboardInterrupt:
+            print("\nGoodbye!")
+            break
+        except Exception as e:
+            log_error(f"Error: {e}")
+            print(f"\nError: {e}\n")
+
+
+async def main():
+    agent = await build_agent()
+    await chat(agent)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+---
+
+## Step 4: Run the Agent
+
+```bash
+python ads_agent.py
+```
+
+You should see the agent initialize, discover tools, and present an interactive prompt.
+
+### Test Prompts
+
+Try these prompts in order:
+
+**1. Account Discovery:**
+```
+What advertiser accounts do I have access to?
+```
+
+**2. List Campaigns:**
+```
+List the campaigns on account <ACCOUNT_ID>
+```
+(Use an account ID from the previous response)
+
+**3. Campaign Creation:**
+```
+Create a Sponsored Products campaign on account <ACCOUNT_ID> with name "Test Campaign", daily budget $10, state PAUSED
+```
+
+---
+
+## Step 5: Review the Complete File Structure
+
+```text
+workshop-ads-agent/
+├── .venv/
+├── .env                  # Your credentials (do not commit)
+├── requirements.txt      # Dependencies
+├── verify_setup.py       # Environment check (Module 1)
+├── test_connection.py    # MCP connection test (Module 2)
+└── ads_agent.py          # The agent (this module)
+```
+
+**What you built:**
+
+- OAuth token exchange to authenticate with the Amazon Ads MCP Server
+- Tool discovery via Streamable HTTP with optional group filtering
+- A LangGraph ReAct agent using Claude via the Anthropic API
+- An interactive chat loop for testing advertising workflows
+
+---
+
+[← Previous: Connect to Amazon Ads MCP Server](02-connect-ads-mcp-server.md) | [Next: Testing and Cleanup →](04-testing-and-cleanup.md)

--- a/amazon-ads-mcp-workshop-non-aws/04-testing-and-cleanup.md
+++ b/amazon-ads-mcp-workshop-non-aws/04-testing-and-cleanup.md
@@ -1,0 +1,162 @@
+---
+title: "Module 4: Testing and Cleanup"
+description: Test the agent with structured scenarios, troubleshoot common issues, and clean up the workshop environment.
+---
+
+# Module 4: Testing and Cleanup
+
+>[NOTE] Run structured test scenarios against your agent, troubleshoot common issues, and clean up your workshop environment.
+
+## When to Use
+
+- You have completed Module 3 and have a working agent
+- You want to verify the agent handles different advertising workflows correctly
+
+---
+
+## Step 1: Run Structured Tests
+
+Create a file called `test_agent.py` that runs predefined prompts against the agent:
+
+```python
+"""Structured tests for the Amazon Ads agent."""
+
+import asyncio
+import sys
+
+# Import the build_agent function from your agent module
+from ads_agent import build_agent
+
+
+async def run_tests():
+    print("Building agent...")
+    agent = await build_agent()
+
+    tests = [
+        {
+            "name": "Account Discovery",
+            "prompt": "List all my advertiser accounts with their IDs, names, and marketplace.",
+            "expect": ["account", "advertiser"],
+        },
+        {
+            "name": "Tool Listing",
+            "prompt": "What tools do you have available? List the tool names grouped by category.",
+            "expect": ["account_management", "campaign_management"],
+        },
+    ]
+
+    passed = 0
+    for test in tests:
+        print(f"\n{'=' * 60}")
+        print(f"TEST: {test['name']}")
+        print(f"{'=' * 60}")
+        print(f"Prompt: {test['prompt'][:80]}...")
+
+        try:
+            response = await agent.ainvoke(
+                {"messages": [{"role": "user", "content": test["prompt"]}]}
+            )
+            reply = response["messages"][-1].content
+            print(f"\nResponse:\n{reply[:500]}...")
+
+            result_lower = reply.lower()
+            hits = [term for term in test["expect"] if term in result_lower]
+            if len(hits) == len(test["expect"]):
+                print(f"\nResult: PASS (found: {hits})")
+                passed += 1
+            else:
+                missing = [t for t in test["expect"] if t not in result_lower]
+                print(f"\nResult: PARTIAL (missing: {missing})")
+
+        except Exception as e:
+            print(f"\nResult: FAIL ({e})")
+
+    print(f"\n{'=' * 60}")
+    print(f"Results: {passed}/{len(tests)} tests passed")
+    print(f"{'=' * 60}")
+
+
+if __name__ == "__main__":
+    asyncio.run(run_tests())
+```
+
+Run the tests:
+
+```bash
+python test_agent.py
+```
+
+---
+
+## Step 2: Troubleshooting
+
+### OAuth / Connection Errors
+
+| Issue | Solution |
+|---|---|
+| **403 Forbidden** | Verify the `Authorization` header contains the raw access token (no `Bearer` prefix). Check that your Client ID and Refresh Token are correct. |
+| **401 Unauthorized** | Your access token may have expired. The token is short-lived — re-run the agent to get a fresh one. |
+| **429 Rate Limited** | The agent includes retry logic with backoff. If it persists, wait a few minutes before retrying. |
+| **Connection refused** | Verify the MCP Server URL matches your region (NA, EU, or FE). |
+
+### Agent Errors
+
+| Issue | Solution |
+|---|---|
+| **ModuleNotFoundError: langchain** | Activate your virtual environment: `source .venv/bin/activate` |
+| **Anthropic API key invalid** | Verify `ANTHROPIC_API_KEY` in your `.env` file. Get a key from [console.anthropic.com](https://console.anthropic.com/). |
+| **No tools discovered** | Check your OAuth credentials. Run `python test_connection.py` from Module 2 to isolate the issue. |
+| **Agent doesn't call tools** | The `TOOL_FILTER` may be too restrictive. Try removing it or expanding the groups. |
+
+### Quick Diagnostic Checklist
+
+- [ ] Virtual environment is activated (`(.venv)` in prompt)
+- [ ] `.env` file contains all 4 required variables
+- [ ] `python test_connection.py` discovers tools successfully
+- [ ] Anthropic API key is valid (test at [console.anthropic.com](https://console.anthropic.com/))
+
+---
+
+## Step 3: Cleanup
+
+To remove all workshop resources:
+
+```bash
+# Deactivate the virtual environment
+deactivate
+
+# Delete the workshop directory
+rm -rf workshop-ads-agent
+```
+
+That's it — no cloud resources to clean up since everything ran locally.
+
+---
+
+## What You Built
+
+Across this workshop you:
+
+1. Connected to the Amazon Ads MCP Server via Streamable HTTP with OAuth authentication
+2. Discovered 50+ advertising tools using the MCP protocol
+3. Built a LangGraph agent powered by Claude (Anthropic API) that orchestrates Ads API calls
+4. Tested the agent with account discovery and campaign management workflows
+
+### Next Steps
+
+- Explore additional tool groups beyond `account_management`, `campaign_management`, and `reporting`
+- Add conversation memory for multi-turn interactions
+- Build a web UI using Streamlit or Gradio
+- For production deployments with AWS hosting, see the [full AWS workshop](../merged-workshop/01-overview.md) which covers Amazon Bedrock AgentCore deployment
+
+### Resources
+
+- [Amazon Ads MCP Server documentation](https://advertising.amazon.com/API/docs/en-us/mcp/get-started)
+- [Amazon Ads API documentation](https://advertising.amazon.com/API/docs/en-us)
+- [LangGraph documentation](https://langchain-ai.github.io/langgraph/)
+- [Anthropic API documentation](https://docs.anthropic.com/)
+- [Workshop code on GitHub](https://github.com/amzn/ads-advanced-tools-docs/tree/main/gen-ai-samples)
+
+---
+
+[← Previous: Build an Ads Agent](03-build-ads-agent.md)

--- a/amazon-ads-mcp-workshop-non-aws/README.md
+++ b/amazon-ads-mcp-workshop-non-aws/README.md
@@ -1,0 +1,58 @@
+# Amazon Ads MCP Workshop (Non-AWS)
+
+Build an AI agent that manages Amazon Ads campaigns using the Model Context Protocol (MCP) and Claude via the Anthropic API. No AWS account required — everything runs locally.
+
+## Prerequisites
+
+- Python 3.13+
+- Anthropic API key ([console.anthropic.com](https://console.anthropic.com/))
+- Amazon Ads API credentials (Client ID, Client Secret, Refresh Token)
+
+## Modules
+
+| Module | Title | Time |
+|---|---|---|
+| [01](01-overview-and-setup.md) | Overview and Setup | 15 min |
+| [02](02-connect-ads-mcp-server.md) | Connect to Amazon Ads MCP Server | 20 min |
+| [03](03-build-ads-agent.md) | Build an Ads Agent | 45 min |
+| [04](04-testing-and-cleanup.md) | Testing and Cleanup | 20 min |
+
+**Total estimated time: ~1.5 hours**
+
+## What You Will Build
+
+- OAuth authentication with the Amazon Ads MCP Server
+- Tool discovery via Streamable HTTP (50+ advertising tools)
+- A LangGraph agent powered by Claude that orchestrates Ads API calls
+- Interactive chat for account discovery, campaign management, and reporting
+
+## Architecture
+
+```
+┌─────────────────────┐
+│    User Prompt       │
+└──────────┬──────────┘
+           │
+           ▼
+┌─────────────────────┐
+│   LangGraph Agent    │
+│   (runs locally)     │
+└──────────┬──────────┘
+           │
+     ┌─────┴──────┐
+     │             │
+     ▼             ▼
+┌──────────┐  ┌──────────────┐
+│ Anthropic│  │  Amazon Ads  │
+│   API    │  │  MCP Server  │
+│ (Claude) │  │              │
+└──────────┘  └──────────────┘
+```
+
+## Contributors
+
+Created by [Chintan Sanghavi](https://www.linkedin.com/in/chintansanghavi/) and [Christelle Ngambula](https://www.linkedin.com/in/chrisngambula/), Senior Solutions Architects at Amazon Ads.
+
+## Looking for the AWS version?
+
+The [full AWS workshop](https://advertising.amazon.com/API/docs/en-us/bulksheets/hands-on-workshops/amazon-ads-mcp-server/08-build-ads-agent#step-4-create-the-ads-campaign-agent) covers Amazon Bedrock AgentCore deployment, custom MCP servers, Knowledge Bases, and more (~4 hours, 10 modules).


### PR DESCRIPTION
… campaign management using MCP and Claude

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
