### PR TITLE
Add CAPI custom attributes sample code with 5 use-case examples

### DIFF
--- a/custom-attributes-events-apis/.env.example
+++ b/custom-attributes-events-apis/.env.example
@@ -1,0 +1,15 @@
+# Amazon Ads API Credentials
+# Copy this file to .env and fill in your values
+# NEVER commit the .env file to version control
+
+# Login with Amazon (LWA) OAuth credentials
+CLIENT_ID=amzn1.application-oa2-client.your_client_id_here
+CLIENT_SECRET=amzn1.oa2-cs.v1.your_client_secret_here
+REFRESH_TOKEN=Atzr|your_refresh_token_here
+
+# Amazon Ads Account ID (required)
+# This is your advertiser account ID (entity ID format)
+ADVERTISER_ID=ENTITY_YOUR_ADVERTISER_ID
+
+# Optional: Manager Account ID (for agency setups)
+# MANAGER_ACCOUNT_ID=amzn1.ads1.ma1.your_manager_account_id

--- a/custom-attributes-events-apis/.gitignore
+++ b/custom-attributes-events-apis/.gitignore
@@ -1,0 +1,5 @@
+.env
+.venv/
+__pycache__/
+*.pyc
+.DS_Store

--- a/custom-attributes-events-apis/LICENSE
+++ b/custom-attributes-events-apis/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Amazon Ads
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/custom-attributes-events-apis/README.md
+++ b/custom-attributes-events-apis/README.md
@@ -1,0 +1,270 @@
+# Amazon Ads Events API — Custom Attributes Sample Code
+
+Working examples for sending custom attributes via the Amazon Ads Events API (Ads API v1).
+
+**API Endpoint:** `POST /adsApi/v1/create/events`  
+**API Docs:** [Events API Reference](https://advertising.amazon.com/API/docs/en-us/amazon-ads/1-0/betas#tag/Events)
+
+## Overview
+
+This repository provides ready-to-run Python code for integrating custom attributes into your Amazon Ads conversion events. Each example maps to a real-world use case:
+
+| Use Case | Script | Payload |
+|----------|--------|---------|
+| Lead Scoring | `src/examples/lead_scoring.py` | `payloads/lead_scoring.json` |
+| Subscription Renewal & LTV | `src/examples/subscription_renewal.py` | `payloads/subscription_renewal.json` |
+| Retail Margin Optimization | `src/examples/retail_margin.py` | `payloads/retail_margin.json` |
+| Promotion & Discount Efficiency | `src/examples/promotion_efficiency.py` | `payloads/promotion_efficiency.json` |
+| Customer Loyalty & Retention | `src/examples/customer_loyalty.py` | `payloads/customer_loyalty.json` |
+
+## Prerequisites
+
+- Python 3.9+
+- An Amazon Ads developer account with API access
+- OAuth 2.0 credentials (Client ID, Client Secret, Refresh Token)
+- An Advertiser Account ID with Events API permissions
+
+### Don't have API credentials yet?
+
+If you haven't set up API access, follow the [Amazon Ads API Onboarding Guide](https://advertising.amazon.com/API/docs/en-us/guides/onboarding/overview) to:
+
+1. **Create a Login with Amazon (LWA) application** — this gives you your `CLIENT_ID` and `CLIENT_SECRET`
+2. **Register as a developer** on the Amazon Ads API portal
+3. **Request API access** and get your application approved
+4. **Generate a Refresh Token** via the OAuth 2.0 authorization flow
+5. **Locate your Advertiser Account ID** in the Amazon Ads console
+
+The onboarding guide walks through each step in detail. Once complete, you'll have all the credentials needed to run the examples below.
+
+## Quickstart
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/amzn/ads-advanced-tools-docs.git
+cd ads-advanced-tools-docs/custom-attributes-events-apis
+```
+
+### 2. Set up your environment
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### 3. Configure credentials
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` with your credentials:
+
+```
+CLIENT_ID=amzn1.application-oa2-client.your_client_id
+CLIENT_SECRET=amzn1.oa2-cs.v1.your_client_secret
+REFRESH_TOKEN=Atzr|your_refresh_token
+ADVERTISER_ID=ENTITY_YOUR_ADVERTISER_ID
+```
+
+> **Note:** If you don't have these values, complete the [onboarding steps](https://advertising.amazon.com/API/docs/en-us/guides/onboarding/overview) first.
+
+### 4. Run an example
+
+Each example is a standalone script. Run any of them from the project root:
+
+```bash
+# Lead Scoring
+python src/examples/lead_scoring.py
+
+# Subscription Renewal & LTV
+python src/examples/subscription_renewal.py
+
+# Retail Margin Optimization
+python src/examples/retail_margin.py
+
+# Promotion & Discount Efficiency
+python src/examples/promotion_efficiency.py
+
+# Customer Loyalty & Retention
+python src/examples/customer_loyalty.py
+```
+
+### 5. Verify the response
+
+A successful run will output something like:
+
+```
+Access token refreshed successfully.
+Sending event to NA endpoint...
+Payload: {
+  "events": [
+    {
+      "eventDescription": { ... },
+      "countryCode": "US",
+      "eventTime": "2026-07-06T14:30:00Z",
+      "matchKeys": [ ... ],
+      "value": 59.99,
+      "currencyCode": "USD",
+      "customData": [ ... ]
+    }
+  ]
+}
+Response: {
+  "success": [
+    { "event": { ... }, "index": 0 }
+  ],
+  "error": []
+}
+
+Event sent successfully! Index: 0
+```
+
+If you see errors, check:
+- **401 Unauthorized** — Your refresh token may be expired. Generate a new one via the OAuth flow.
+- **403 Forbidden** — Your account may not have `event_manager_view` or `event_manager_edit` permissions.
+- **400 Bad Request** — Check that your `ADVERTISER_ID` and `dataSetName` are valid for your account.
+
+## Project Structure
+
+```
+capi-custom-attributes-samples/
+├── README.md
+├── .env.example
+├── .gitignore
+├── requirements.txt
+├── LICENSE
+├── src/
+│   ├── __init__.py
+│   ├── auth.py                 # OAuth 2.0 token management
+│   ├── client.py               # Events API HTTP client
+│   ├── send_event.py           # Core event building & submission logic
+│   └── examples/
+│       ├── __init__.py
+│       ├── lead_scoring.py
+│       ├── subscription_renewal.py
+│       ├── retail_margin.py
+│       ├── promotion_efficiency.py
+│       └── customer_loyalty.py
+├── payloads/
+│   ├── lead_scoring.json
+│   ├── subscription_renewal.json
+│   ├── retail_margin.json
+│   ├── promotion_efficiency.json
+│   └── customer_loyalty.json
+└── docs/
+    └── custom_attributes_guide.md
+```
+
+## API Details
+
+### Endpoint
+
+```
+POST https://advertising-api.amazon.com/adsApi/v1/create/events
+```
+
+Regional endpoints:
+| Region | Base URL |
+|--------|----------|
+| North America | `https://advertising-api.amazon.com` |
+| Europe | `https://advertising-api-eu.amazon.com` |
+| Far East | `https://advertising-api-fe.amazon.com` |
+
+### Required Headers
+
+| Header | Description |
+|--------|-------------|
+| `Authorization` | `Bearer <access_token>` from OAuth 2.0 |
+| `Amazon-Ads-AccountId` | Your Advertiser Account ID |
+| `Amazon-Ads-ClientId` | Your LWA application Client ID |
+| `Content-Type` | `application/json` |
+
+### Required Permissions
+
+The API requires one of: `event_manager_view` or `event_manager_edit`.
+
+## Custom Attributes Reference
+
+Amazon Ads Events API supports up to **13 custom attributes** per event:
+- 10 fully custom attributes
+- 3 reserved attributes: `brand`, `product`, `category`
+
+Each attribute is defined with:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Attribute identifier. Only letters, numbers, and underscores allowed. |
+| `dataType` | string | One of: `STRING`, `INTEGER`, `TIMESTAMP` |
+| `value` | string | The attribute value. Only letters, numbers, and underscores allowed. |
+
+### Conversion Types
+
+| Value | Description |
+|-------|-------------|
+| `OFF_AMAZON_PURCHASES` | Purchase of a product or service |
+| `LEAD` | Action that initiates a sales lead |
+| `SIGN_UP` | Sign-up for a product or service |
+| `SUBSCRIBE` | Subscription to a service |
+| `APPLICATION` | Application submission |
+| `ADD_TO_SHOPPING_CART` | Product added to cart |
+| `PAGE_VIEW` | Page visit on your website |
+| `SEARCH` | Product search |
+| `CONTACT` | Contact information provided |
+| `CHECKOUT` | Checkout page visit |
+| `OTHER` | Actions not fitting standard types |
+
+### Match Key Types
+
+| Type | Description | Hashing |
+|------|-------------|---------|
+| `EMAIL` | Email address | SHA-256 (normalized, lowercased) |
+| `PHONE` | Phone number | SHA-256 (digits + leading `+` only) |
+| `FIRST_NAME` | First name | SHA-256 |
+| `LAST_NAME` | Last name | SHA-256 |
+| `ADDRESS` | Street address | SHA-256 |
+| `CITY` | City | SHA-256 |
+| `STATE` | State/region | SHA-256 |
+| `POSTAL` | Postal/zip code | SHA-256 |
+| `MAID` | Mobile Advertising ID (ADID, IDFA, FIREADID) | Raw value |
+| `RAMP_ID` | LiveRamp RAMP ID | Raw value |
+| `MATCH_ID` | Match ID | Raw value |
+
+## Best Practices
+
+- **Naming:** Use consistent `snake_case` — only letters, numbers, and underscores
+- **Values:** Same character constraint as names — only letters, numbers, and underscores. For monetary values, use cents as integers (e.g., `"4999"` for $49.99)
+- **Timing:** Send events as close to conversion time as possible
+- **Batching:** Up to 500 events per API request
+- **Deduplication:** Use `eventId` to prevent duplicate event processing
+- **Hashing:** Always SHA-256 hash PII match keys (email, phone, name, address)
+- **Selectivity:** Only include attributes that drive optimization or reporting decisions
+
+## Error Handling
+
+The API returns HTTP `207` (Multi-Status) with `success` and `error` arrays:
+
+```json
+{
+  "success": [{ "event": {...}, "index": 0 }],
+  "error": [{ "errors": [...], "index": 1 }]
+}
+```
+
+The examples include handling for:
+- Token expiration and automatic refresh
+- Rate limiting (HTTP 429) with exponential backoff
+- Server errors (HTTP 5xx) with retry logic
+- Request timeouts
+
+## Related Resources
+
+- [Amazon Ads API Onboarding Guide](https://advertising.amazon.com/API/docs/en-us/guides/onboarding/overview)
+- [Events API Reference (Ads API v1)](https://advertising.amazon.com/API/docs/en-us/amazon-ads/1-0/betas#tag/Events)
+- [Blog: Unlock Smarter Ad Optimization with Custom Attributes](https://advertising.amazon.com/blog/custom-attributes-capi)
+- [Amazon Ads Developer Portal](https://advertising.amazon.com/API/docs/en-us)
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/custom-attributes-events-apis/docs/custom_attributes_guide.md
+++ b/custom-attributes-events-apis/docs/custom_attributes_guide.md
@@ -1,0 +1,49 @@
+# Custom Attributes Guide
+
+For the full conceptual guide and use case explanations, see the companion blog post:
+
+**[Unlock Smarter Ad Optimization: How to Send Custom Attributes via Amazon Ads Conversion API](https://advertising.amazon.com/blog/custom-attributes-capi)**
+
+## Quick Reference
+
+### Attribute Limits
+- Maximum 13 custom attributes per event
+- 10 fully custom + 3 reserved (`brand`, `product`, `category`)
+
+### Payload Structure
+
+```json
+"customData": [
+  { "name": "attribute_name", "dataType": "STRING", "value": "your_value" }
+]
+```
+
+### Naming Rules
+- Use `snake_case` consistently
+- No leading/trailing spaces
+- No special characters
+- Keep names descriptive but concise
+
+### Data Type Encoding
+All values are sent as strings regardless of their semantic type:
+
+| Semantic Type | dataType Field | Value Format |
+|---------------|---------------|--------------|
+| Text | `STRING` | `"premium"` |
+| Number | `STRING` | `"49.99"` |
+| Boolean | `STRING` | `"true"` / `"false"` |
+| Integer | `STRING` | `"12"` |
+
+### Reserved Attributes
+
+These three attribute names have special meaning in Amazon Ads reporting:
+
+| Name | Purpose |
+|------|---------|
+| `brand` | Product or company brand name |
+| `product` | Product identifier or name |
+| `category` | Product or service category |
+
+## Running the Examples
+
+See the [main README](../README.md) for setup and execution instructions.

--- a/custom-attributes-events-apis/payloads/customer_loyalty.json
+++ b/custom-attributes-events-apis/payloads/customer_loyalty.json
@@ -1,0 +1,31 @@
+{
+  "events": [
+    {
+      "eventDescription": {
+        "name": "PURCHASE",
+        "conversionType": "OFF_AMAZON_PURCHASES",
+        "eventSource": "WEBSITE",
+        "dataSetName": "LoyaltyProgram",
+        "eventIngestionMethod": "SERVER_TO_SERVER"
+      },
+      "countryCode": "US",
+      "eventTime": "2026-06-17T16:35:00Z",
+      "matchKeys": [
+        {
+          "type": "EMAIL",
+          "values": [
+            "d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5"
+          ]
+        }
+      ],
+      "value": 129.99,
+      "customData": [
+        { "name": "loyalty_status", "dataType": "STRING", "value": "member" },
+        { "name": "loyalty_tier", "dataType": "STRING", "value": "gold" },
+        { "name": "retention_segment", "dataType": "STRING", "value": "high_value_existing" },
+        { "name": "lifetime_revenue", "dataType": "INTEGER", "value": "245000" },
+        { "name": "months_as_member", "dataType": "INTEGER", "value": "24" }
+      ]
+    }
+  ]
+}

--- a/custom-attributes-events-apis/payloads/lead_scoring.json
+++ b/custom-attributes-events-apis/payloads/lead_scoring.json
@@ -1,0 +1,30 @@
+{
+  "events": [
+    {
+      "eventDescription": {
+        "name": "LEAD_SUBMISSION",
+        "conversionType": "LEAD",
+        "eventSource": "WEBSITE",
+        "dataSetName": "LeadGenCampaign",
+        "eventIngestionMethod": "SERVER_TO_SERVER"
+      },
+      "countryCode": "US",
+      "eventTime": "2026-06-17T16:35:00Z",
+      "matchKeys": [
+        {
+          "type": "EMAIL",
+          "values": [
+            "4e308dac739dbf0744ce16c6498fc34f7039bc7032a7af3b09f5a50e3ff63fff"
+          ]
+        }
+      ],
+      "value": 450.00,
+      "customData": [
+        { "name": "lead_score", "dataType": "STRING", "value": "high_intent" },
+        { "name": "predicted_value", "dataType": "INTEGER", "value": "450" },
+        { "name": "lead_source", "dataType": "STRING", "value": "website_form" },
+        { "name": "customer_segment", "dataType": "STRING", "value": "enterprise" }
+      ]
+    }
+  ]
+}

--- a/custom-attributes-events-apis/payloads/promotion_efficiency.json
+++ b/custom-attributes-events-apis/payloads/promotion_efficiency.json
@@ -1,0 +1,31 @@
+{
+  "events": [
+    {
+      "eventDescription": {
+        "name": "PURCHASE",
+        "conversionType": "OFF_AMAZON_PURCHASES",
+        "eventSource": "WEBSITE",
+        "dataSetName": "RetailOrders",
+        "eventIngestionMethod": "SERVER_TO_SERVER"
+      },
+      "countryCode": "US",
+      "eventTime": "2026-06-17T16:35:00Z",
+      "matchKeys": [
+        {
+          "type": "EMAIL",
+          "values": [
+            "c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"
+          ]
+        }
+      ],
+      "value": 89.99,
+      "customData": [
+        { "name": "coupon_used", "dataType": "STRING", "value": "false" },
+        { "name": "discount_status", "dataType": "STRING", "value": "no_discount" },
+        { "name": "full_price_flag", "dataType": "STRING", "value": "true" },
+        { "name": "promo_type", "dataType": "STRING", "value": "none" },
+        { "name": "deal_event", "dataType": "STRING", "value": "none" }
+      ]
+    }
+  ]
+}

--- a/custom-attributes-events-apis/payloads/retail_margin.json
+++ b/custom-attributes-events-apis/payloads/retail_margin.json
@@ -1,0 +1,30 @@
+{
+  "events": [
+    {
+      "eventDescription": {
+        "name": "PURCHASE",
+        "conversionType": "OFF_AMAZON_PURCHASES",
+        "eventSource": "WEBSITE",
+        "dataSetName": "RetailOrders",
+        "eventIngestionMethod": "SERVER_TO_SERVER"
+      },
+      "countryCode": "US",
+      "eventTime": "2026-06-17T16:35:00Z",
+      "matchKeys": [
+        {
+          "type": "EMAIL",
+          "values": [
+            "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3"
+          ]
+        }
+      ],
+      "value": 49.99,
+      "customData": [
+        { "name": "price_of_unit", "dataType": "INTEGER", "value": "4999" },
+        { "name": "product_margin_percentage", "dataType": "INTEGER", "value": "65" },
+        { "name": "product_category", "dataType": "STRING", "value": "electronics" },
+        { "name": "is_private_label", "dataType": "STRING", "value": "true" }
+      ]
+    }
+  ]
+}

--- a/custom-attributes-events-apis/payloads/subscription_renewal.json
+++ b/custom-attributes-events-apis/payloads/subscription_renewal.json
@@ -1,0 +1,31 @@
+{
+  "events": [
+    {
+      "eventDescription": {
+        "name": "SUBSCRIPTION_RENEWAL",
+        "conversionType": "OFF_AMAZON_PURCHASES",
+        "eventSource": "WEBSITE",
+        "dataSetName": "SubscriptionEvents",
+        "eventIngestionMethod": "SERVER_TO_SERVER"
+      },
+      "countryCode": "US",
+      "eventTime": "2026-06-17T16:35:00Z",
+      "matchKeys": [
+        {
+          "type": "EMAIL",
+          "values": [
+            "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+          ]
+        }
+      ],
+      "value": 59.99,
+      "customData": [
+        { "name": "subscription_type", "dataType": "STRING", "value": "premium" },
+        { "name": "renewal_cycle", "dataType": "INTEGER", "value": "12" },
+        { "name": "is_active_subscriber", "dataType": "STRING", "value": "true" },
+        { "name": "lifetime_revenue", "dataType": "INTEGER", "value": "71988" },
+        { "name": "months_as_customer", "dataType": "INTEGER", "value": "36" }
+      ]
+    }
+  ]
+}

--- a/custom-attributes-events-apis/requirements.txt
+++ b/custom-attributes-events-apis/requirements.txt
@@ -1,0 +1,2 @@
+requests==2.32.3
+python-dotenv==1.1.0

--- a/custom-attributes-events-apis/src/auth.py
+++ b/custom-attributes-events-apis/src/auth.py
@@ -1,0 +1,116 @@
+"""OAuth 2.0 authentication for Amazon Ads API.
+
+This module handles the Login with Amazon (LWA) OAuth 2.0 token lifecycle.
+It exchanges a long-lived refresh token for short-lived access tokens,
+automatically refreshing when tokens expire.
+
+Flow:
+    1. On first API call, the refresh token is exchanged for an access token
+    2. Access tokens are cached in memory and reused until they expire
+    3. Tokens are refreshed automatically 60 seconds before expiry to avoid
+       failed requests due to token expiration during transit
+
+Prerequisites:
+    - CLIENT_ID: Your LWA application's client ID
+    - CLIENT_SECRET: Your LWA application's client secret
+    - REFRESH_TOKEN: A long-lived token obtained via the OAuth authorization flow
+
+Author: Chintan Sanghavi
+Date: July 6, 2026
+"""
+
+import time
+import logging
+import requests
+import os
+
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+# Amazon's OAuth 2.0 token endpoint for Login with Amazon (LWA)
+TOKEN_URL = "https://api.amazon.com/auth/o2/token"
+
+
+class AmazonAdsAuth:
+    """Manages OAuth 2.0 token lifecycle for Amazon Ads API.
+
+    This class encapsulates the token refresh logic so that calling code
+    can simply access `self.access_token` without worrying about expiry.
+
+    Usage:
+        auth = AmazonAdsAuth()
+        headers = {"Authorization": f"Bearer {auth.access_token}"}
+    """
+
+    def __init__(self):
+        # Load credentials from environment variables
+        self.client_id = os.getenv("CLIENT_ID")
+        self.client_secret = os.getenv("CLIENT_SECRET")
+        self.refresh_token = os.getenv("REFRESH_TOKEN")
+
+        # Internal state for token caching
+        self._access_token = None
+        self._token_expiry = 0  # Unix timestamp when the token expires
+
+        # Validate that all required credentials are present
+        if not all([self.client_id, self.client_secret, self.refresh_token]):
+            raise ValueError(
+                "Missing required credentials. "
+                "Ensure CLIENT_ID, CLIENT_SECRET, "
+                "and REFRESH_TOKEN are set in your .env file."
+            )
+
+    @property
+    def access_token(self) -> str:
+        """Returns a valid access token, refreshing if expired.
+
+        This property is the main interface for getting a usable token.
+        It transparently handles refresh logic — callers don't need to
+        worry about token expiry.
+        """
+        if self._is_token_expired():
+            self._refresh_access_token()
+        return self._access_token
+
+    def _is_token_expired(self) -> bool:
+        """Check if the current token is expired or about to expire.
+
+        We refresh 60 seconds before actual expiry to provide a buffer
+        and avoid race conditions where a token expires mid-request.
+        """
+        return time.time() >= (self._token_expiry - 60)
+
+    def _refresh_access_token(self):
+        """Exchange the refresh token for a new access token.
+
+        Makes a POST request to Amazon's OAuth token endpoint with
+        the refresh_token grant type. The response includes a new
+        access token and its TTL (typically 3600 seconds / 1 hour).
+
+        Raises:
+            requests.HTTPError: If the token refresh request fails
+                (e.g., invalid credentials, revoked refresh token).
+        """
+        payload = {
+            "grant_type": "refresh_token",
+            "refresh_token": self.refresh_token,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+
+        # POST to LWA token endpoint with TLS verification enabled
+        response = requests.post(
+            TOKEN_URL, data=payload, timeout=30, verify=True
+        )
+        response.raise_for_status()
+
+        # Extract the new access token and compute expiry time
+        token_data = response.json()
+        self._access_token = token_data["access_token"]
+        self._token_expiry = time.time() + token_data.get("expires_in", 3600)
+
+        logger.info("Access token refreshed successfully.")

--- a/custom-attributes-events-apis/src/client.py
+++ b/custom-attributes-events-apis/src/client.py
@@ -1,0 +1,180 @@
+"""Amazon Ads Events API (CAPI v1) HTTP client.
+
+This module provides a robust HTTP client for sending conversion events
+to the Amazon Ads Events API. It handles:
+    - Authentication via OAuth 2.0 (delegated to AmazonAdsAuth)
+    - Regional endpoint selection (NA, EU, FE)
+    - Automatic retries with exponential backoff for rate limits (429)
+      and server errors (5xx)
+    - Request timeouts to prevent hanging connections
+
+Endpoint: POST /adsApi/v1/create/events
+Docs: https://advertising.amazon.com/API/docs/en-us/amazon-ads/1-0/betas#tag/Events
+
+Author: Chintan Sanghavi
+Date: July 6, 2026
+"""
+
+import time
+import json
+import logging
+import requests
+import os
+
+from dotenv import load_dotenv
+from src.auth import AmazonAdsAuth
+
+# Load environment variables from .env file
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+# Regional API endpoints — choose based on where your advertiser account is located
+# NA = North America, EU = Europe, FE = Far East (Japan, Australia)
+API_ENDPOINTS = {
+    "NA": "https://advertising-api.amazon.com",
+    "EU": "https://advertising-api-eu.amazon.com",
+    "FE": "https://advertising-api-fe.amazon.com",
+}
+
+# Retry configuration for transient failures
+MAX_RETRIES = 3                  # Total attempts before giving up
+INITIAL_BACKOFF_SECONDS = 1      # First retry waits 1s, then 2s, then 4s
+
+
+class CAPIClient:
+    """HTTP client for the Amazon Ads Events API (Ads API v1).
+
+    Creates events via: POST /adsApi/v1/create/events
+
+    Required headers:
+        - Authorization: Bearer <access_token>
+        - Amazon-Ads-AccountId: The advertiser account ID
+        - Amazon-Ads-ClientId: The LWA client ID
+        - Content-Type: application/json
+
+    Usage:
+        client = CAPIClient(region="NA")
+        response = client.send_conversion_events(payload)
+    """
+
+    def __init__(self, region: str = "NA"):
+        """Initialize the client with authentication and region settings.
+
+        Args:
+            region: The API region to target. One of "NA", "EU", or "FE".
+                   Defaults to "NA" (North America).
+        """
+        # Initialize OAuth authentication (will validate credentials)
+        self.auth = AmazonAdsAuth()
+
+        # Load advertiser ID from environment
+        self.advertiser_id = os.getenv("ADVERTISER_ID")
+        self.region = region
+
+        # Select the appropriate regional endpoint
+        self.base_url = API_ENDPOINTS.get(region, API_ENDPOINTS["NA"])
+
+        if not self.advertiser_id:
+            raise ValueError(
+                "ADVERTISER_ID is required. Set it in your .env file."
+            )
+
+    def send_conversion_events(self, payload: dict) -> dict:
+        """
+        Send conversion events to the Amazon Ads Events API.
+
+        This method handles the full request lifecycle:
+        1. Constructs the request URL and headers
+        2. Sends the POST request with the event payload
+        3. Retries on rate limits (429) and server errors (5xx)
+        4. Returns the parsed response on success (207)
+
+        POST /adsApi/v1/create/events
+
+        Args:
+            payload: The complete event payload. Must contain an "events" array
+                     with 1-500 EventCreate objects.
+
+        Returns:
+            The API response as a dictionary. The 207 multi-status response
+            contains two arrays:
+                - "success": Events that were accepted
+                - "error": Events that failed with error details
+
+        Raises:
+            requests.HTTPError: If the request fails after all retries.
+            requests.exceptions.Timeout: If all attempts time out.
+        """
+        url = f"{self.base_url}/adsApi/v1/create/events"
+        headers = self._build_headers()
+
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                # Send the POST request with JSON payload
+                # verify=True ensures TLS certificate validation
+                response = requests.post(
+                    url,
+                    json=payload,
+                    headers=headers,
+                    timeout=30,
+                    verify=True,
+                )
+
+                # Handle rate limiting — wait and retry with exponential backoff
+                if response.status_code == 429:
+                    wait_time = INITIAL_BACKOFF_SECONDS * (2 ** (attempt - 1))
+                    logger.warning(
+                        "Rate limited (429). Retrying in %ds (attempt %d/%d)...",
+                        wait_time, attempt, MAX_RETRIES,
+                    )
+                    time.sleep(wait_time)
+                    continue
+
+                # Handle server errors — these are usually transient
+                if response.status_code >= 500:
+                    wait_time = INITIAL_BACKOFF_SECONDS * (2 ** (attempt - 1))
+                    logger.warning(
+                        "Server error (%d). Retrying in %ds (attempt %d/%d)...",
+                        response.status_code, wait_time, attempt, MAX_RETRIES,
+                    )
+                    time.sleep(wait_time)
+                    continue
+
+                # 207 Multi-Status is the expected success response
+                # It contains per-event success/error details
+                if response.status_code == 207:
+                    return response.json()
+
+                # For any other status code, raise an exception
+                response.raise_for_status()
+                return response.json()
+
+            except requests.exceptions.Timeout:
+                logger.warning(
+                    "Request timed out (attempt %d/%d)...",
+                    attempt, MAX_RETRIES,
+                )
+                # Only raise on the final attempt; earlier attempts loop back
+                if attempt == MAX_RETRIES:
+                    raise
+
+        # If we exhausted all retries without returning, raise the last error
+        response.raise_for_status()
+        return response.json()
+
+    def _build_headers(self) -> dict:
+        """Construct request headers per API spec.
+
+        The Amazon Ads Events API requires four headers:
+        - Authorization: OAuth 2.0 Bearer token
+        - Amazon-Ads-AccountId: Identifies which advertiser account to use
+        - Amazon-Ads-ClientId: Identifies the calling application
+        - Content-Type: Must be application/json
+        """
+        return {
+            "Authorization": f"Bearer {self.auth.access_token}",
+            "Amazon-Ads-AccountId": self.advertiser_id,
+            "Amazon-Ads-ClientId": self.auth.client_id,
+            "Content-Type": "application/json",
+        }

--- a/custom-attributes-events-apis/src/examples/customer_loyalty.py
+++ b/custom-attributes-events-apis/src/examples/customer_loyalty.py
@@ -1,0 +1,90 @@
+"""
+Example: Customer Loyalty & Retention Optimization
+
+Use case: Brands with loyalty programs sending membership tier and
+retention context to support loyalty-focused campaign strategies.
+
+How it works:
+    When a loyalty member makes a purchase, this script sends their
+    membership tier, tenure, and retention segment as custom attributes.
+    This helps the ad platform distinguish between:
+    - True new customer acquisition (growing the customer base)
+    - Existing loyal customers who would have bought anyway
+    - Lapsed members who need reactivation
+
+    Without these signals, 70%+ of ad-driven purchases may come from
+    existing members — meaning you're paying to acquire customers you
+    already have.
+
+Custom attributes sent:
+    - loyalty_status: Whether the buyer is a member or non-member
+    - loyalty_tier: Membership level (e.g., "gold", "platinum", "silver")
+    - retention_segment: Business classification of the customer
+    - lifetime_revenue: Total historical revenue in cents (integer)
+    - months_as_member: How long they've been a member (integer)
+
+Author: Chintan Sanghavi
+Date: July 6, 2026
+"""
+
+import os
+import sys
+
+# Add project root to path so we can import src modules
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.send_event import build_event_payload, hash_email, send_conversion_event
+
+
+def main():
+    """Send a purchase event with loyalty/retention custom attributes."""
+
+    # Step 1: Build match keys from hashed PII
+    match_keys = [
+        {
+            "type": "EMAIL",
+            "values": [hash_email("loyalmember@example.com")],
+        }
+    ]
+
+    # Step 2: Define custom attributes for loyalty segmentation
+    # These attributes enable the ad platform to:
+    #   - Separate acquisition from retention in reporting
+    #   - Build lookalike audiences from your best customers
+    #   - Avoid spending budget on customers who'd convert organically
+    #
+    # lifetime_revenue uses cents as INTEGER (245000 = $2,450.00)
+    # to comply with the API's alphanumeric-only value constraint.
+    custom_data = [
+        {"name": "loyalty_status", "dataType": "STRING", "value": "member"},
+        {"name": "loyalty_tier", "dataType": "STRING", "value": "gold"},
+        {"name": "retention_segment", "dataType": "STRING", "value": "high_value_existing"},
+        {"name": "lifetime_revenue", "dataType": "INTEGER", "value": "245000"},
+        {"name": "months_as_member", "dataType": "INTEGER", "value": "24"},
+    ]
+
+    # Step 3: Build the event payload
+    payload = build_event_payload(
+        event_name="PURCHASE",
+        conversion_type="OFF_AMAZON_PURCHASES",
+        dataset_name="LoyaltyProgram",
+        country_code="US",
+        match_keys=match_keys,
+        value=129.99,
+        currency_code="USD",
+        custom_data=custom_data,
+    )
+
+    # Step 4: Send the event
+    response = send_conversion_event(payload)
+
+    # Step 5: Check the response
+    if "success" in response and response["success"]:
+        print(f"\nCustomer loyalty event sent successfully! "
+              f"Index: {response['success'][0]['index']}")
+    if "error" in response and response["error"]:
+        print(f"\nEvent had errors: {response['error']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/custom-attributes-events-apis/src/examples/lead_scoring.py
+++ b/custom-attributes-events-apis/src/examples/lead_scoring.py
@@ -1,0 +1,85 @@
+"""
+Example: Lead Scoring & Predictive Value
+
+Use case: Automotive, financial, and B2B advertisers sending lead quality
+signals to optimize bids toward high-value prospects.
+
+How it works:
+    When a potential customer submits a lead form (loan application, test drive
+    request, etc.), your CRM scores the lead based on qualification criteria.
+    This script sends that lead score as a custom attribute alongside the
+    conversion event, enabling the ad platform to learn which audiences
+    produce the highest-quality leads — not just the most leads.
+
+Custom attributes sent:
+    - lead_score: Qualitative tier (e.g., "high_intent", "medium", "low")
+    - predicted_value: Estimated dollar value of the lead (as integer cents)
+    - lead_source: Where the lead originated (e.g., "website_form")
+    - customer_segment: Business classification (e.g., "enterprise", "smb")
+
+Author: Chintan Sanghavi
+Date: July 6, 2026
+"""
+
+import os
+import sys
+
+# Add project root to path so we can import src modules
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.send_event import build_event_payload, hash_email, send_conversion_event
+
+
+def main():
+    """Send a lead scoring conversion event with custom attributes."""
+
+    # Step 1: Build match keys from hashed PII
+    # The API requires email addresses to be SHA-256 hashed for privacy.
+    # hash_email() normalizes (lowercase, strip) then hashes the email.
+    match_keys = [
+        {
+            "type": "EMAIL",
+            "values": [hash_email("customer@example.com")],
+        }
+    ]
+
+    # Step 2: Define custom attributes for lead scoring
+    # These attributes tell the ad platform about the QUALITY of this lead,
+    # not just that a lead occurred. This enables value-based bidding.
+    # Note: Values must be alphanumeric + underscore only (no dots or special chars).
+    # For monetary values, use integer representation (e.g., "450" for $450).
+    custom_data = [
+        {"name": "lead_score", "dataType": "STRING", "value": "high_intent"},
+        {"name": "predicted_value", "dataType": "INTEGER", "value": "450"},
+        {"name": "lead_source", "dataType": "STRING", "value": "website_form"},
+        {"name": "customer_segment", "dataType": "STRING", "value": "enterprise"},
+    ]
+
+    # Step 3: Build the event payload
+    # conversion_type="LEAD" indicates this is a lead generation event.
+    # The value field represents the predicted monetary value of this lead.
+    payload = build_event_payload(
+        event_name="LEAD_SUBMISSION",
+        conversion_type="LEAD",
+        dataset_name="LeadGenCampaign",
+        country_code="US",
+        match_keys=match_keys,
+        value=450.00,
+        custom_data=custom_data,
+    )
+
+    # Step 4: Send the event to Amazon Ads Events API
+    # The response contains "success" and "error" arrays indicating
+    # which events were accepted or rejected.
+    response = send_conversion_event(payload)
+
+    # Step 5: Check the response
+    if "success" in response and response["success"]:
+        print(f"\nLead scoring event sent successfully! "
+              f"Index: {response['success'][0]['index']}")
+    if "error" in response and response["error"]:
+        print(f"\nEvent had errors: {response['error']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/custom-attributes-events-apis/src/examples/promotion_efficiency.py
+++ b/custom-attributes-events-apis/src/examples/promotion_efficiency.py
@@ -1,0 +1,84 @@
+"""
+Example: Promotion & Discount Efficiency
+
+Use case: Brands separating full-price demand from discount-subsidized
+demand to understand true campaign effectiveness.
+
+How it works:
+    When a purchase occurs, this script flags whether the buyer used a
+    coupon, received a discount, or paid full price. This prevents the
+    ad platform from training exclusively on discount-driven buyers
+    during sales events, which can crater post-promotion performance.
+
+Custom attributes sent:
+    - coupon_used: Whether any coupon was applied ("true" or "false")
+    - discount_status: Discount category ("no_discount", "seasonal", "clearance")
+    - full_price_flag: Whether the purchase was at full price
+    - promo_type: Type of promotion active ("none", "bogo", "percentage_off")
+    - deal_event: Whether tied to a deal event ("none", "prime_day", "black_friday")
+
+Author: Chintan Sanghavi
+Date: July 6, 2026
+"""
+
+import os
+import sys
+
+# Add project root to path so we can import src modules
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.send_event import build_event_payload, hash_email, send_conversion_event
+
+
+def main():
+    """Send a purchase event with promotion/discount context attributes."""
+
+    # Step 1: Build match keys from hashed PII
+    match_keys = [
+        {
+            "type": "EMAIL",
+            "values": [hash_email("buyer@example.com")],
+        }
+    ]
+
+    # Step 2: Define custom attributes for promotion tracking
+    # This example shows a FULL PRICE purchase (no discount applied).
+    # For discounted purchases, you'd change these values accordingly:
+    #   coupon_used="true", discount_status="seasonal", full_price_flag="false"
+    #
+    # This data helps the ad platform distinguish between:
+    #   - Customers with genuine brand affinity (buy at full price)
+    #   - Discount-seekers (only buy during sales)
+    custom_data = [
+        {"name": "coupon_used", "dataType": "STRING", "value": "false"},
+        {"name": "discount_status", "dataType": "STRING", "value": "no_discount"},
+        {"name": "full_price_flag", "dataType": "STRING", "value": "true"},
+        {"name": "promo_type", "dataType": "STRING", "value": "none"},
+        {"name": "deal_event", "dataType": "STRING", "value": "none"},
+    ]
+
+    # Step 3: Build the event payload
+    payload = build_event_payload(
+        event_name="PURCHASE",
+        conversion_type="OFF_AMAZON_PURCHASES",
+        dataset_name="RetailOrders",
+        country_code="US",
+        match_keys=match_keys,
+        value=89.99,
+        currency_code="USD",
+        custom_data=custom_data,
+    )
+
+    # Step 4: Send the event
+    response = send_conversion_event(payload)
+
+    # Step 5: Check the response
+    if "success" in response and response["success"]:
+        print(f"\nPromotion efficiency event sent successfully! "
+              f"Index: {response['success'][0]['index']}")
+    if "error" in response and response["error"]:
+        print(f"\nEvent had errors: {response['error']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/custom-attributes-events-apis/src/examples/retail_margin.py
+++ b/custom-attributes-events-apis/src/examples/retail_margin.py
@@ -1,0 +1,82 @@
+"""
+Example: Retail Margin Optimization
+
+Use case: E-commerce brands sending margin and profitability data
+to optimize for net-profit ROAS rather than raw revenue.
+
+How it works:
+    When a purchase occurs, this script sends the product's margin data
+    as custom attributes. This allows the ad platform to optimize toward
+    profitable products rather than just expensive ones. A $50 accessory
+    with 65% margin is more valuable than a $500 TV with 3% margin.
+
+Custom attributes sent:
+    - price_of_unit: Unit price in cents (integer, e.g., 4999 = $49.99)
+    - product_margin_percentage: Margin as integer percentage (e.g., 65 = 65%)
+    - product_category: Product category for segmentation
+    - is_private_label: Whether this is a higher-margin private label product
+
+Author: Chintan Sanghavi
+Date: July 6, 2026
+"""
+
+import os
+import sys
+
+# Add project root to path so we can import src modules
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.send_event import build_event_payload, hash_email, send_conversion_event
+
+
+def main():
+    """Send a purchase event with margin/profitability custom attributes."""
+
+    # Step 1: Build match keys from hashed PII
+    match_keys = [
+        {
+            "type": "EMAIL",
+            "values": [hash_email("shopper@example.com")],
+        }
+    ]
+
+    # Step 2: Define custom attributes for margin optimization
+    # Key insight: Use INTEGER type for numeric values.
+    # Represent monetary values in cents (4999 = $49.99) and
+    # percentages as whole numbers (65 = 65%) to comply with the
+    # API constraint that values can only contain [A-Za-z0-9_].
+    custom_data = [
+        {"name": "price_of_unit", "dataType": "INTEGER", "value": "4999"},
+        {"name": "product_margin_percentage", "dataType": "INTEGER", "value": "65"},
+        {"name": "product_category", "dataType": "STRING", "value": "electronics"},
+        {"name": "is_private_label", "dataType": "STRING", "value": "true"},
+    ]
+
+    # Step 3: Build the event payload
+    # The top-level "value" field is the purchase amount (used for ROAS calculation).
+    # The custom attributes provide the MARGIN context that turns revenue-based
+    # optimization into profit-based optimization.
+    payload = build_event_payload(
+        event_name="PURCHASE",
+        conversion_type="OFF_AMAZON_PURCHASES",
+        dataset_name="RetailOrders",
+        country_code="US",
+        match_keys=match_keys,
+        value=49.99,
+        currency_code="USD",
+        custom_data=custom_data,
+    )
+
+    # Step 4: Send the event
+    response = send_conversion_event(payload)
+
+    # Step 5: Check the response
+    if "success" in response and response["success"]:
+        print(f"\nRetail margin event sent successfully! "
+              f"Index: {response['success'][0]['index']}")
+    if "error" in response and response["error"]:
+        print(f"\nEvent had errors: {response['error']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/custom-attributes-events-apis/src/examples/subscription_renewal.py
+++ b/custom-attributes-events-apis/src/examples/subscription_renewal.py
@@ -1,0 +1,98 @@
+"""
+Example: Subscription Renewals & LTV Optimization
+
+Use case: SaaS, media, and telecom brands sending renewal and retention
+signals to maximize Customer Lifetime Value optimization.
+
+How it works:
+    When a subscriber renews their subscription, this script sends the
+    renewal event enriched with subscription tier, renewal count, and
+    lifetime revenue. This teaches the ad platform what a "retainable"
+    subscriber looks like at acquisition time, shifting bid optimization
+    from "cheapest sign-up" to "longest-retained customer."
+
+Custom attributes sent:
+    - subscription_type: Plan tier (e.g., "premium", "standard", "free")
+    - renewal_cycle: How many times this customer has renewed (integer)
+    - is_active_subscriber: Current subscription status
+    - lifetime_revenue: Total revenue from this customer in cents (integer)
+    - months_as_customer: Tenure length in months (integer)
+
+API: POST /adsApi/v1/create/events
+Docs: https://advertising.amazon.com/API/docs/en-us/amazon-ads/1-0/betas#tag/Events
+
+Author: Chintan Sanghavi
+Date: July 6, 2026
+"""
+
+import os
+import sys
+
+# Add project root to path so we can import src modules
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.send_event import build_event_payload, hash_email, send_conversion_event
+
+
+def main():
+    """Send a subscription renewal event with LTV custom attributes."""
+
+    # Step 1: Build match keys from hashed PII
+    # Per API spec: match key values must be SHA-256 hashed for PII types.
+    # Each match key type can have exactly 1 value in the "values" array.
+    match_keys = [
+        {
+            "type": "EMAIL",
+            "values": [hash_email("subscriber@example.com")],
+        }
+    ]
+
+    # Step 2: Define custom attributes (max 13 per event)
+    # These attributes provide the ad platform with customer lifetime value
+    # signals, enabling optimization toward high-retention subscribers.
+    #
+    # Per API spec:
+    #   - name: only letters, numbers, and underscore (snake_case)
+    #   - dataType: STRING | INTEGER | TIMESTAMP
+    #   - value: only letters, numbers, and underscore
+    #
+    # For monetary values, use cents as INTEGER (e.g., 71988 = $719.88)
+    custom_data = [
+        {"name": "subscription_type", "dataType": "STRING", "value": "premium"},
+        {"name": "renewal_cycle", "dataType": "INTEGER", "value": "12"},
+        {"name": "is_active_subscriber", "dataType": "STRING", "value": "true"},
+        {"name": "lifetime_revenue", "dataType": "INTEGER", "value": "71988"},
+        {"name": "months_as_customer", "dataType": "INTEGER", "value": "36"},
+    ]
+
+    # Step 3: Build the event payload
+    # conversion_type="OFF_AMAZON_PURCHASES" since this is a paid transaction.
+    # event_id provides deduplication — if this event is accidentally sent twice,
+    # the API will only process it once.
+    payload = build_event_payload(
+        event_name="SUBSCRIPTION_RENEWAL",
+        conversion_type="OFF_AMAZON_PURCHASES",
+        dataset_name="SubscriptionEvents",
+        country_code="US",
+        match_keys=match_keys,
+        custom_data=custom_data,
+        value=59.99,
+        currency_code="USD",
+        event_source="WEBSITE",
+        event_id="renewal_evt_20260706_001",  # Deduplication ID
+    )
+
+    # Step 4: Send to Amazon Ads Events API (NA region)
+    response = send_conversion_event(payload, region="NA")
+
+    # Step 5: Check response — API returns 207 with success/error arrays
+    # A 207 Multi-Status response means the request was received; check
+    # individual event results in the success/error arrays.
+    if "success" in response and response["success"]:
+        print(f"\nEvent sent successfully! Index: {response['success'][0]['index']}")
+    if "error" in response and response["error"]:
+        print(f"\nEvent had errors: {response['error']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/custom-attributes-events-apis/src/send_event.py
+++ b/custom-attributes-events-apis/src/send_event.py
@@ -1,0 +1,288 @@
+"""Core event submission logic for Amazon Ads Events API (Ads API v1).
+
+This module provides the main building blocks for constructing and sending
+conversion events with custom attributes. It includes:
+    - build_event_payload(): Constructs a valid API request payload
+    - hash_email() / hash_phone(): PII hashing utilities for match keys
+    - send_conversion_event(): High-level function to send an event
+
+The module enforces API constraints at build time (before the request is sent)
+to provide clear error messages and prevent malformed requests.
+
+Author: Chintan Sanghavi
+Date: July 6, 2026
+
+API Reference: POST /adsApi/v1/create/events
+Schema: EventCreate object
+
+Key constraints from the OpenAPI spec:
+- events array: 1-500 items per request
+- customData array: 0-13 items per event
+- customData.name: Only letters, numbers, and underscore allowed
+- customData.dataType: STRING | INTEGER | TIMESTAMP
+- customData.value: Only letters, numbers, and underscore allowed
+- matchKeys array: 1-14 items per event
+- matchKeys.values: exactly 1 value per match key
+- countryCode: required (ISO 3166-1 alpha-2)
+- eventTime: required (ISO 8601 datetime)
+- eventDescription: required (conversionType, eventIngestionMethod, eventSource, name)
+"""
+
+import hashlib
+import json
+import logging
+import os
+import re
+from datetime import datetime, timezone
+from typing import Optional
+
+from src.client import CAPIClient
+
+logger = logging.getLogger(__name__)
+
+# Validation pattern for custom attribute names and values per API spec.
+# The API only accepts alphanumeric characters and underscores.
+# Values like "49.99" (with dots) or "high-intent" (with hyphens) will be rejected.
+VALID_ATTRIBUTE_PATTERN = re.compile(r"^[A-Za-z0-9_]+$")
+
+
+def build_event_payload(
+    event_name: str,
+    conversion_type: str,
+    dataset_name: str,
+    country_code: str,
+    match_keys: list[dict],
+    custom_data: list[dict],
+    value: Optional[float] = None,
+    currency_code: Optional[str] = None,
+    event_source: str = "WEBSITE",
+    event_time: Optional[str] = None,
+    event_id: Optional[str] = None,
+    units_sold: Optional[int] = None,
+) -> dict:
+    """
+    Build a complete Events API payload conforming to the Ads API v1 spec.
+
+    This function constructs the JSON payload that will be sent to the API.
+    It validates inputs against API constraints before building the payload,
+    so errors are caught early with clear messages.
+
+    Args:
+        event_name: The name of the imported event (e.g., "SUBSCRIPTION_RENEWAL").
+            This identifies the type of action the customer took.
+        conversion_type: The category of conversion. Must be one of:
+            ADD_TO_SHOPPING_CART, APPLICATION, CHECKOUT, CONTACT, LEAD,
+            OFF_AMAZON_PURCHASES, MOBILE_APP_FIRST_START, PAGE_VIEW,
+            SEARCH, SIGN_UP, SUBSCRIBE, OTHER.
+        dataset_name: Event DataSet name that groups related events.
+            Pattern: [A-Za-z][A-Za-z0-9_-]* (must start with a letter).
+        country_code: ISO 3166-1 alpha-2 country code (e.g., "US", "GB", "DE").
+        match_keys: List of match key objects used to identify the user.
+            Each object has "type" (e.g., "EMAIL") and "values" (list with
+            one SHA-256 hashed value). Used to match conversions to ad exposures.
+        custom_data: List of custom attribute dicts. Each must have:
+            - "name": Attribute identifier (alphanumeric + underscore only)
+            - "dataType": One of "STRING", "INTEGER", "TIMESTAMP"
+            - "value": The attribute value (alphanumeric + underscore only)
+        value: Monetary value for OFF_AMAZON_PURCHASES (in the currency unit,
+            e.g., 59.99 for $59.99). Non-monetary for other conversion types.
+        currency_code: ISO 4217 currency code (e.g., "USD", "EUR").
+            Required when value represents a monetary amount.
+        event_source: Where the conversion occurred. One of: WEBSITE, ANDROID,
+            IOS, FIRE_TV, OFFLINE, MEASUREMENT_ATTRIBUTION_PARTNER.
+            Defaults to "WEBSITE".
+        event_time: ISO 8601 timestamp of when the conversion happened.
+            Defaults to current UTC time if not provided.
+            Must be within 24-48 hours for optimal attribution matching.
+        event_id: Client-specified deduplication ID. If the same event_id
+            is sent multiple times, the API will deduplicate it.
+        units_sold: Number of items purchased (only for OFF_AMAZON_PURCHASES).
+
+    Returns:
+        A dictionary representing the complete API request payload,
+        ready to be sent as JSON to the Events API endpoint.
+
+    Raises:
+        ValueError: If custom_data exceeds 13 attributes, match_keys exceeds 14,
+            or attribute names/values contain invalid characters.
+
+    Example:
+        payload = build_event_payload(
+            event_name="PURCHASE",
+            conversion_type="OFF_AMAZON_PURCHASES",
+            dataset_name="RetailOrders",
+            country_code="US",
+            match_keys=[{"type": "EMAIL", "values": ["<sha256_hash>"]}],
+            custom_data=[
+                {"name": "loyalty_tier", "dataType": "STRING", "value": "gold"}
+            ],
+            value=49.99,
+            currency_code="USD",
+        )
+    """
+    # Default to current UTC time if no event time provided
+    if event_time is None:
+        event_time = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # --- Input validation against API constraints ---
+
+    # The API allows a maximum of 13 custom attributes per event
+    # (10 fully custom + 3 reserved: brand, product, category)
+    if len(custom_data) > 13:
+        raise ValueError(
+            f"Maximum 13 custom attributes allowed per event, got {len(custom_data)}."
+        )
+
+    # The API allows a maximum of 14 match keys per event
+    if len(match_keys) > 14:
+        raise ValueError(
+            f"Maximum 14 match keys allowed per event, got {len(match_keys)}."
+        )
+
+    # Validate each custom attribute against the API's character constraints
+    for attr in custom_data:
+        # Attribute names must be alphanumeric + underscore (snake_case)
+        if not VALID_ATTRIBUTE_PATTERN.match(attr["name"]):
+            raise ValueError(
+                f"Invalid custom attribute name '{attr['name']}'. "
+                "Only letters, numbers, and underscores are allowed."
+            )
+        # Attribute values must also be alphanumeric + underscore
+        # For monetary values, use cents as integers (e.g., "4999" for $49.99)
+        if not VALID_ATTRIBUTE_PATTERN.match(attr["value"]):
+            raise ValueError(
+                f"Invalid custom attribute value '{attr['value']}' for '{attr['name']}'. "
+                "Only letters, numbers, and underscores are allowed."
+            )
+        # Validate dataType is one of the three supported types
+        if attr["dataType"] not in ("STRING", "INTEGER", "TIMESTAMP"):
+            raise ValueError(
+                f"Invalid dataType '{attr['dataType']}' for '{attr['name']}'. "
+                "Must be STRING, INTEGER, or TIMESTAMP."
+            )
+
+    # --- Build the event object ---
+
+    # eventDescription contains metadata about the type of event
+    event = {
+        "eventDescription": {
+            "name": event_name,
+            "conversionType": conversion_type,
+            "eventSource": event_source,
+            "dataSetName": dataset_name,
+            "eventIngestionMethod": "SERVER_TO_SERVER",  # Always server-side for CAPI
+        },
+        "countryCode": country_code,
+        "eventTime": event_time,
+        "matchKeys": match_keys,
+    }
+
+    # Add custom attributes (the core feature of this sample code)
+    if custom_data:
+        event["customData"] = custom_data
+
+    # Add optional monetary value (e.g., purchase amount)
+    if value is not None:
+        event["value"] = value
+
+    # Add currency code (required when value is monetary)
+    if currency_code is not None:
+        event["currencyCode"] = currency_code
+
+    # Add deduplication ID to prevent duplicate event processing
+    if event_id is not None:
+        event["eventId"] = event_id
+
+    # Add units sold (only applicable for purchase events)
+    if units_sold is not None:
+        event["unitsSold"] = units_sold
+
+    # Wrap in the top-level "events" array (API accepts 1-500 events per request)
+    return {"events": [event]}
+
+
+def hash_email(email: str) -> str:
+    """
+    Normalize and hash an email address with SHA-256 for use as a match key.
+
+    The Amazon Ads API requires PII match keys to be SHA-256 hashed before
+    sending. This function applies the normalization rules from the API docs
+    before hashing to ensure consistent matching.
+
+    Normalization rules (per API docs):
+    - Lowercase the entire email
+    - Remove leading/trailing whitespace
+
+    Args:
+        email: The raw email address (e.g., "User@Example.COM")
+
+    Returns:
+        A 64-character hex string representing the SHA-256 hash of the
+        normalized email (e.g., "a1b2c3d4...").
+
+    Example:
+        hashed = hash_email("customer@example.com")
+        match_key = {"type": "EMAIL", "values": [hashed]}
+    """
+    normalized = email.strip().lower()
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def hash_phone(phone: str) -> str:
+    """
+    Normalize and hash a phone number with SHA-256 for use as a match key.
+
+    Strips all characters except digits and the leading '+' sign,
+    then hashes the result. This ensures consistent matching regardless
+    of how the phone number was formatted (parentheses, dashes, spaces).
+
+    Args:
+        phone: The raw phone number (e.g., "+1 (555) 123-4567")
+
+    Returns:
+        A 64-character hex string representing the SHA-256 hash.
+
+    Example:
+        hashed = hash_phone("+15551234567")
+        match_key = {"type": "PHONE", "values": [hashed]}
+    """
+    # Keep only digits and the leading + sign
+    cleaned = "".join(c for c in phone if c.isdigit() or c == "+")
+    return hashlib.sha256(cleaned.encode("utf-8")).hexdigest()
+
+
+def send_conversion_event(payload: dict, region: str = "NA") -> dict:
+    """
+    Send a conversion event to the Amazon Ads Events API.
+
+    This is the high-level convenience function that:
+    1. Creates an authenticated API client for the specified region
+    2. Sends the payload to the Events API endpoint
+    3. Returns the parsed response
+
+    Args:
+        payload: The complete event payload built by build_event_payload().
+        region: API region - "NA" (North America), "EU" (Europe),
+                or "FE" (Far East). Defaults to "NA".
+
+    Returns:
+        The API response dictionary (207 multi-status) containing:
+        - "success": List of accepted events with their index
+        - "error": List of rejected events with error details
+
+    Example:
+        payload = build_event_payload(...)
+        response = send_conversion_event(payload, region="NA")
+        if response["success"]:
+            print(f"Event accepted at index {response['success'][0]['index']}")
+    """
+    client = CAPIClient(region=region)
+    logger.info("Sending event to %s endpoint...", region)
+    logger.debug(
+        "Payload (event count: %d)", len(payload.get("events", []))
+    )
+    response = client.send_conversion_events(payload)
+    logger.info("Response received (success: %d, errors: %d)",
+                len(response.get("success", [])),
+                len(response.get("error", [])))
+    return response


### PR DESCRIPTION
## Summary

Adds working Python sample code for sending custom attributes via the Amazon Ads Events API (CAPI v2). This accompanies the "Custom Attributes via Conversion API" blog post on the developer portal.

## What's included

- **5 use-case examples** with real-world scenarios:
  - Lead Scoring & Predictive Value
  - Subscription Renewal & LTV Optimization
  - Retail Margin Optimization
  - Promotion & Discount Efficiency
  - Customer Loyalty & Retention
- **Core modules:**
  - `auth.py` — OAuth 2.0 token management with automatic refresh
  - `client.py` — HTTP client with retry/exponential backoff
  - `send_event.py` — Event payload builder with input validation
- **JSON payload examples** for each use case
- **Documentation** in `docs/custom_attributes_guide.md`

## Security considerations

- No PII logged to stdout (uses Python logging module)
- TLS certificate verification explicitly enforced
- Input validation against API spec constraints (attribute names/values)
- Credentials loaded from `.env` (excluded via `.gitignore`)
- Dependencies pinned to exact versions

## How to test

1. Clone the repo and `pip install -r requirements.txt`
2. Copy `.env.example` to `.env` and fill in credentials
3. Run any example: `python src/examples/lead_scoring.py`
