### PR TITLE
[postman] Add Amazon Ads Unified API collection and separate the two collections in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To stay up to date on the latest additions, add yourself to this repository as a
 
 ## Contents
 
-- [Amazon Ads API Postman collection](postman)
+- [Amazon Ads API Postman collections](postman)
 - [Amazon Marketing Stream CloudFormation template](amazon_marketing_stream)
 
 ## Issues

--- a/postman/Amazon_Ads_Unified_API.postman_collection.json
+++ b/postman/Amazon_Ads_Unified_API.postman_collection.json
@@ -1,0 +1,15226 @@
+{
+  "info": {
+    "name": "Amazon Ads Unified API (/adsApi/v1)",
+    "description": "Postman collection for the Amazon Ads API unified interface (/adsApi/v1). Every operation is grouped by resource, with example request bodies and OAuth2 access-token automation. Setup matches the Amazon Ads API Postman collection (https://github.com/amzn/ads-advanced-tools-docs/tree/main/postman): set your client_id and client_secret, obtain an access token via the Auth folder, then set the accountId value sent as the Amazon-Ads-AccountId header.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Auth",
+      "item": [
+        {
+          "name": "Auth grant login",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"response should return form login page\", function () {",
+                  "      pm.response.to.not.be.error;",
+                  "});",
+                  "",
+                  "console.log(`Authorization grant URL: \\n${pm.environment.get('auth_grant_url')}?scope=${pm.environment.get('permission_scope')}&response_type=code&client_id=${pm.environment.get('client_id')}&state=State&redirect_uri=${pm.environment.get('redirect_uri')}\\n`)"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "const jar = pm.cookies.jar()",
+                  "",
+                  "jar.clear(pm.request.url, function (error) {",
+                  "    ",
+                  "})"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{auth_grant_url}}?scope={{permission_scope}}&response_type=code&client_id={{client_id}}&state=State&redirect_uri={{redirect_uri}}",
+              "host": [
+                "{{auth_grant_url}}"
+              ],
+              "query": [
+                {
+                  "key": "scope",
+                  "value": "{{permission_scope}}"
+                },
+                {
+                  "key": "response_type",
+                  "value": "code"
+                },
+                {
+                  "key": "client_id",
+                  "value": "{{client_id}}"
+                },
+                {
+                  "key": "state",
+                  "value": "State"
+                },
+                {
+                  "key": "redirect_uri",
+                  "value": "{{redirect_uri}}"
+                }
+              ]
+            },
+            "description": "[Learn more about authorization grants.](https://advertising.amazon.com/API/docs/en-us/concepts/authorization/authorization-grants)"
+          },
+          "response": []
+        },
+        {
+          "name": "Access token from auth grant code",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"response should not be an error\", function () {",
+                  "      pm.response.to.not.be.error;",
+                  "});",
+                  "",
+                  "// The following script sets Postman environment variables to enable authorization for subsequent requests to the Amazon Ads API. Token freshness for subsequent requests is handled by a collection-level pre-request script. ",
+                  "// See collection documentation for setup information. ",
+                  "// For information about retrieving access tokens for the Amazon Ads API, see https://advertising.amazon.com/API/docs/en-us/concepts/authorization/access-tokens#retrieving-access-tokens",
+                  "",
+                  "const res = JSON.parse(responseBody);",
+                  "if (res.access_token && res.refresh_token) {",
+                  "    postman.setEnvironmentVariable(\"access_token\", res.access_token);",
+                  "    postman.setEnvironmentVariable(\"refresh_token\", res.refresh_token);",
+                  "    postman.setEnvironmentVariable(\"token_expires_at\", Date.now() + (res.expires_in * 1000) - 10000)",
+                  "} else {",
+                  "    console.log('Authorization failed.')",
+                  "    console.log(res)",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "grant_type",
+                  "value": "authorization_code",
+                  "type": "text"
+                },
+                {
+                  "key": "code",
+                  "value": "",
+                  "description": "An authorization code retrieved via Login with Amazon's authorization grant process.",
+                  "type": "text"
+                },
+                {
+                  "key": "redirect_uri",
+                  "value": "{{redirect_uri}}",
+                  "type": "text"
+                },
+                {
+                  "key": "client_id",
+                  "value": "{{client_id}}",
+                  "type": "text"
+                },
+                {
+                  "key": "client_secret",
+                  "value": "{{client_secret}}",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": "{{token_url}}",
+            "description": "[Learn more about access tokens.](https://advertising.amazon.com/API/docs/en-us/concepts/authorization/access-tokens)"
+          },
+          "response": []
+        },
+        {
+          "name": "Access token from refresh token",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"response should not be an error\", function () {",
+                  "      pm.response.to.not.be.error;",
+                  "});",
+                  "",
+                  "// The following script sets Postman environment variables to enable authorization for subsequent requests to the Amazon Ads API. ",
+                  "// NOTE: This request is included for reference, but may not need to be run to use this collection -- token freshness is typically handled by a collection-level pre-request script. ",
+                  "// See collection documentation for setup information. ",
+                  "// For information about retrieving access tokens for the Amazon Ads API, see https://advertising.amazon.com/API/docs/en-us/concepts/authorization/access-tokens#retrieving-access-tokens",
+                  "",
+                  "const res = JSON.parse(responseBody);",
+                  "if (res.access_token && res.refresh_token) {",
+                  "    postman.setEnvironmentVariable(\"access_token\", res.access_token);",
+                  "    postman.setEnvironmentVariable(\"refresh_token\", res.refresh_token);",
+                  "    postman.setEnvironmentVariable(\"token_expires_at\", Date.now() + (res.expires_in * 1000) - 10000)",
+                  "} else {",
+                  "    console.log('Authorization failed.')",
+                  "    console.log(res)",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "grant_type",
+                  "value": "refresh_token",
+                  "type": "text"
+                },
+                {
+                  "key": "refresh_token",
+                  "value": "{{refresh_token}}",
+                  "type": "text"
+                },
+                {
+                  "key": "client_id",
+                  "value": "{{client_id}}",
+                  "type": "text"
+                },
+                {
+                  "key": "client_secret",
+                  "value": "{{client_secret}}",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": "{{token_url}}"
+          },
+          "response": []
+        }
+      ],
+      "description": "Authorization credentials for the Amazon Ads API are administered by Login with Amazon. The requests in the **Auth** folder are directed to Login with Amazon hosts rather than to the host specified for other requests to the API.\n\nLearn more about [Authorization in the Amazon Ads API](https://advertising.amazon.com/API/docs/en-us/concepts/authorization/overview).\n\n[Follow the Postman quickstart guide](https://advertising.amazon.com/API/docs/en-us/getting-started/using-postman-collection) to learn about using the requests in this folder.\n\n## Using tokens in this collection\n\nOnce you have retrieved a refresh token, a pre-request script in this collection will refresh your access token automatically as needed."
+    },
+    {
+      "name": "Unified API \u2014 Prod (3P)",
+      "item": [
+        {
+          "name": "AdAssociations",
+          "item": [
+            {
+              "name": "Create Ad Association",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/adAssociations",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "adAssociations"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"adAssociations\": [\n    {\n      \"state\": \"ENABLED\",\n      \"adId\": \"example-ad-id\",\n      \"adGroupId\": \"example-ad-group-id\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create Ad Association"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/adAssociations",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "adAssociations"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"adAssociations\": [\n    {\n      \"state\": \"ENABLED\",\n      \"adId\": \"example-ad-id\",\n      \"adGroupId\": \"example-ad-group-id\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create Ad Association"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [\n        {\n          \"code\": \"FIELD_VALUE_IS_INVALID\",\n          \"message\": \"Ad does not have any ad experience associated\"\n        }\n      ],\n      \"index\": 0\n    }\n  ],\n  \"success\": []\n}"
+                }
+              ]
+            },
+            {
+              "name": "Delete Ad Association",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/delete/adAssociations",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "delete",
+                    "adAssociations"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"adAssociationIds\": [\n    \"example-ad-association-ids\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Delete Ad Association"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/delete/adAssociations",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "delete",
+                        "adAssociations"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"adAssociationIds\": [\n    \"example-ad-association-ids\"\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Delete Ad Association"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"success\": [\n    {\n      \"adAssociation\": {\n        \"adAssociationId\": \"example-ad-association-id\",\n        \"adGroupId\": \"example-ad-group-id\",\n        \"adId\": \"example-ad-id\",\n        \"state\": \"PAUSED\"\n      },\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Query Ad Association",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/adAssociations",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "adAssociations"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"adGroupIdFilter\": {\n    \"include\": [\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\"\n    ]\n  },\n  \"maxResults\": 100\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query Ad Association"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/adAssociations",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "adAssociations"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"adGroupIdFilter\": {\n    \"include\": [\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\",\n      \"example-include\"\n    ]\n  },\n  \"maxResults\": 100\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query Ad Association"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"adAssociations\": []\n}"
+                }
+              ]
+            },
+            {
+              "name": "Update Ad Association",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/update/adAssociations",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "update",
+                    "adAssociations"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"adAssociations\": [\n    {\n      \"adAssociationId\": \"example-ad-association-id\",\n      \"state\": \"ENABLED\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update Ad Association"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/update/adAssociations",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "update",
+                        "adAssociations"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"adAssociations\": [\n    {\n      \"adAssociationId\": \"example-ad-association-id\",\n      \"state\": \"ENABLED\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Update Ad Association"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"success\": [\n    {\n      \"adAssociation\": {\n        \"adAssociationId\": \"example-ad-association-id\",\n        \"adGroupId\": \"example-ad-group-id\",\n        \"adId\": \"example-ad-id\",\n        \"state\": \"PAUSED\"\n      },\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "AdExtensions",
+          "item": [
+            {
+              "name": "Create ad extensions - API is in open beta",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/adExtensions",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "adExtensions"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"adExtensions\": [\n    {\n      \"adGroupId\": \"example-ad-group-id\",\n      \"adProduct\": \"SPONSORED_PRODUCTS\",\n      \"marketplaces\": [\n        \"US\"\n      ],\n      \"marketplaceScope\": \"SINGLE_MARKETPLACE\",\n      \"state\": \"ENABLED\",\n      \"adExtensionStatus\": \"OPTED_OUT\",\n      \"adExtensionType\": \"PROMPTS\",\n      \"adExtensionSettings\": {\n        \"promptExtension\": {\n          \"promptText\": \"Does NY Threads have a shorts that moisture-wick?\"\n        }\n      }\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create ad extensions - API is in open beta"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/adExtensions",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "adExtensions"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"adExtensions\": [\n    {\n      \"adGroupId\": \"example-ad-group-id\",\n      \"adProduct\": \"SPONSORED_PRODUCTS\",\n      \"marketplaces\": [\n        \"US\"\n      ],\n      \"marketplaceScope\": \"SINGLE_MARKETPLACE\",\n      \"state\": \"ENABLED\",\n      \"adExtensionStatus\": \"OPTED_OUT\",\n      \"adExtensionType\": \"PROMPTS\",\n      \"adExtensionSettings\": {\n        \"promptExtension\": {\n          \"promptText\": \"Does NY Threads have a shorts that moisture-wick?\"\n        }\n      }\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create ad extensions - API is in open beta"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"partialSuccess\": [],\n  \"success\": [\n    {\n      \"adExtension\": {\n        \"adExtensionId\": \"example-ad-extension-id\",\n        \"adExtensionSettings\": {\n          \"promptExtension\": {\n            \"promptText\": \"Does NY Threads have a shorts that moisture-wick?\"\n          }\n        },\n        \"adExtensionStatus\": \"OPTED_OUT\",\n        \"adExtensionType\": \"PROMPTS\",\n        \"adGroupId\": \"example-ad-group-id\",\n        \"adProduct\": \"SPONSORED_PRODUCTS\",\n        \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n        \"lastUpdatedDateTime\": \"2025-01-01T00:00:00Z\",\n        \"marketplaceScope\": \"SINGLE_MARKETPLACE\",\n        \"marketplaces\": [\n          \"US\"\n        ],\n        \"state\": \"ENABLED\"\n      },\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Query ad_extension - API is in open beta",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/adExtensions",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "adExtensions"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"stateFilter\": {\n    \"include\": [\n      \"ENABLED\",\n      \"PAUSED\"\n    ]\n  },\n  \"adProductFilter\": {\n    \"include\": [\n      \"SPONSORED_PRODUCTS\"\n    ]\n  },\n  \"maxResults\": 1000\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query ad_extension - API is in open beta"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/adExtensions",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "adExtensions"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"stateFilter\": {\n    \"include\": [\n      \"ENABLED\",\n      \"PAUSED\"\n    ]\n  },\n  \"adProductFilter\": {\n    \"include\": [\n      \"SPONSORED_PRODUCTS\"\n    ]\n  },\n  \"maxResults\": 1000\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query ad_extension - API is in open beta"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"adExtensions\": [\n    {\n      \"adExtensionId\": \"example-ad-extension-id\",\n      \"adExtensionSettings\": {\n        \"videoExtension\": {\n          \"videoType\": \"SPOTLIGHT\"\n        }\n      },\n      \"adExtensionType\": \"VIDEO\",\n      \"adGroupId\": \"example-ad-group-id\",\n      \"adId\": \"example-ad-id\",\n      \"adProduct\": \"SPONSORED_PRODUCTS\",\n      \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n      \"lastUpdatedDateTime\": \"2025-01-01T00:00:00Z\",\n      \"marketplaceScope\": \"SINGLE_MARKETPLACE\",\n      \"marketplaces\": [\n        \"US\"\n      ],\n      \"state\": \"ENABLED\",\n      \"status\": {\n        \"deliveryReasons\": [\n          \"AD_EXTENSION_POLICING_SUSPENDED\"\n        ],\n        \"deliveryStatus\": \"NOT_DELIVERING\"\n      }\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Update ad_extension - API is in open beta",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/update/adExtensions",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "update",
+                    "adExtensions"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"adExtensions\": [\n    {\n      \"adExtensionId\": \"example-ad-extension-id\",\n      \"state\": \"ENABLED\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update ad_extension - API is in open beta"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/update/adExtensions",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "update",
+                        "adExtensions"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"adExtensions\": [\n    {\n      \"adExtensionId\": \"example-ad-extension-id\",\n      \"state\": \"ENABLED\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Update ad_extension - API is in open beta"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"partialSuccess\": [],\n  \"success\": [\n    {\n      \"adExtension\": {\n        \"adExtensionId\": \"example-ad-extension-id\",\n        \"adExtensionSettings\": {\n          \"videoExtension\": {\n            \"renderedAssetId\": \"example-rendered-asset-id\",\n            \"videoType\": \"SPOTLIGHT\"\n          }\n        },\n        \"adExtensionType\": \"VIDEO\",\n        \"adGroupId\": \"example-ad-group-id\",\n        \"adId\": \"example-ad-id\",\n        \"adProduct\": \"SPONSORED_PRODUCTS\",\n        \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n        \"lastUpdatedDateTime\": \"2025-01-01T00:00:00Z\",\n        \"marketplaceScope\": \"SINGLE_MARKETPLACE\",\n        \"marketplaces\": [\n          \"US\"\n        ],\n        \"state\": \"ENABLED\"\n      },\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "AdGroups",
+          "item": [
+            {
+              "name": "Create ad groups",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/adGroups",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "adGroups"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"adGroups\": [\n    {\n      \"adProduct\": \"SPONSORED_TELEVISION\",\n      \"campaignId\": \"example-campaign-id\",\n      \"name\": \"Sample name\",\n      \"state\": \"ENABLED\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create ad groups"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/adGroups",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "adGroups"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"adGroups\": [\n    {\n      \"adProduct\": \"SPONSORED_TELEVISION\",\n      \"campaignId\": \"example-campaign-id\",\n      \"name\": \"Sample name\",\n      \"state\": \"ENABLED\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create ad groups"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [\n        {\n          \"code\": \"FIELD_VALUE_NOT_FOUND\",\n          \"message\": \"Campaign not found\"\n        }\n      ],\n      \"index\": 0\n    }\n  ],\n  \"partialSuccess\": [],\n  \"success\": []\n}"
+                }
+              ]
+            },
+            {
+              "name": "Delete ad groups",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/delete/adGroups",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "delete",
+                    "adGroups"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"adGroupIds\": [\n    \"example-ad-group-ids\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Delete ad groups"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/delete/adGroups",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "delete",
+                        "adGroups"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"adGroupIds\": [\n    \"example-ad-group-ids\"\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Delete ad groups"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"partialSuccess\": [],\n  \"success\": [\n    {\n      \"adGroup\": {\n        \"adGroupId\": \"example-ad-group-id\",\n        \"adProduct\": \"SPONSORED_PRODUCTS\",\n        \"bid\": {\n          \"currencyCode\": \"USD\",\n          \"defaultBid\": 1.31\n        },\n        \"campaignId\": \"example-campaign-id\",\n        \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n        \"lastUpdatedDateTime\": \"2025-01-01T00:00:00Z\",\n        \"marketplaceScope\": \"SINGLE_MARKETPLACE\",\n        \"marketplaces\": [\n          \"US\"\n        ],\n        \"name\": \"Sample name\",\n        \"state\": \"ARCHIVED\",\n        \"tags\": []\n      },\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "List ad groups",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/adGroups",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "adGroups"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"stateFilter\": {\n    \"include\": [\n      \"ENABLED\",\n      \"PAUSED\"\n    ]\n  },\n  \"adProductFilter\": {\n    \"include\": [\n      \"SPONSORED_PRODUCTS\"\n    ]\n  },\n  \"maxResults\": 1000\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "List ad groups"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/adGroups",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "adGroups"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"stateFilter\": {\n    \"include\": [\n      \"ENABLED\",\n      \"PAUSED\"\n    ]\n  },\n  \"adProductFilter\": {\n    \"include\": [\n      \"SPONSORED_PRODUCTS\"\n    ]\n  },\n  \"maxResults\": 1000\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "List ad groups"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"adGroups\": [\n    {\n      \"adGroupId\": \"example-ad-group-id\",\n      \"adProduct\": \"SPONSORED_PRODUCTS\",\n      \"bid\": {\n        \"currencyCode\": \"EUR\",\n        \"defaultBid\": 0.7\n      },\n      \"campaignId\": \"example-campaign-id\",\n      \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n      \"lastUpdatedDateTime\": \"2025-01-01T00:00:00Z\",\n      \"marketplaceScope\": \"SINGLE_MARKETPLACE\",\n      \"marketplaces\": [\n        \"BE\"\n      ],\n      \"name\": \"Sample name\",\n      \"state\": \"ENABLED\",\n      \"status\": {\n        \"deliveryReasons\": [],\n        \"deliveryStatus\": \"DELIVERING\"\n      },\n      \"tags\": []\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Update ad groups",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/update/adGroups",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "update",
+                    "adGroups"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"adGroups\": [\n    {\n      \"adGroupId\": \"example-ad-group-id\",\n      \"state\": \"ENABLED\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update ad groups"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/update/adGroups",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "update",
+                        "adGroups"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"adGroups\": [\n    {\n      \"adGroupId\": \"example-ad-group-id\",\n      \"state\": \"ENABLED\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Update ad groups"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [\n        {\n          \"code\": \"ARCHIVED_RESOURCE_CANNOT_EDIT\",\n          \"message\": \"archived object cannot be modified\"\n        }\n      ],\n      \"index\": 0\n    }\n  ],\n  \"partialSuccess\": [],\n  \"success\": []\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Ads",
+          "item": [
+            {
+              "name": "Create ads",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/ads",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "ads"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"ads\": [\n    {\n      \"adGroupId\": \"example-ad-group-id\",\n      \"adProduct\": \"SPONSORED_TELEVISION\",\n      \"adType\": \"VIDEO\",\n      \"state\": \"ENABLED\",\n      \"name\": \"Sample name\",\n      \"creative\": {\n        \"videoCreative\": {\n          \"streamingTvSettings\": {\n            \"landingPage\": {\n              \"landingPageType\": \"STORE\",\n              \"landingPageUrl\": \"example-landing-page-url\"\n            },\n            \"videos\": {\n              \"assetId\": \"0123456\",\n              \"assetVersion\": \"version_v1\"\n            }\n          }\n        }\n      }\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create ads"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/ads",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "ads"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"ads\": [\n    {\n      \"adGroupId\": \"example-ad-group-id\",\n      \"adProduct\": \"SPONSORED_TELEVISION\",\n      \"adType\": \"VIDEO\",\n      \"state\": \"ENABLED\",\n      \"name\": \"Sample name\",\n      \"creative\": {\n        \"videoCreative\": {\n          \"streamingTvSettings\": {\n            \"landingPage\": {\n              \"landingPageType\": \"STORE\",\n              \"landingPageUrl\": \"example-landing-page-url\"\n            },\n            \"videos\": {\n              \"assetId\": \"0123456\",\n              \"assetVersion\": \"version_v1\"\n            }\n          }\n        }\n      }\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create ads"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [\n        {\n          \"code\": \"FIELD_VALUE_IS_INVALID\",\n          \"message\": \"Invalid Asset ID or Asset Version\"\n        }\n      ],\n      \"index\": 0\n    }\n  ],\n  \"partialSuccess\": [],\n  \"success\": []\n}"
+                }
+              ]
+            },
+            {
+              "name": "Delete ads",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/delete/ads",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "delete",
+                    "ads"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"adIds\": [\n    \"example-ad-ids\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Delete ads"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/delete/ads",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "delete",
+                        "ads"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"adIds\": [\n    \"example-ad-ids\"\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Delete ads"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"partialSuccess\": [],\n  \"success\": [\n    {\n      \"ad\": {\n        \"adId\": \"example-ad-id\"\n      },\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "List ads",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/ads",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "ads"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"stateFilter\": {\n    \"include\": [\n      \"ENABLED\",\n      \"PAUSED\",\n      \"ARCHIVED\"\n    ]\n  },\n  \"adProductFilter\": {\n    \"include\": [\n      \"SPONSORED_BRANDS\"\n    ]\n  },\n  \"maxResults\": 100,\n  \"nextToken\": \"A05360581AYF7NQJEEW1N\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "List ads"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/ads",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "ads"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"stateFilter\": {\n    \"include\": [\n      \"ENABLED\",\n      \"PAUSED\",\n      \"ARCHIVED\"\n    ]\n  },\n  \"adProductFilter\": {\n    \"include\": [\n      \"SPONSORED_BRANDS\"\n    ]\n  },\n  \"maxResults\": 100,\n  \"nextToken\": \"A05360581AYF7NQJEEW1N\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "List ads"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"ads\": [\n    {\n      \"adGroupId\": \"example-ad-group-id\",\n      \"adId\": \"example-ad-id\",\n      \"adProduct\": \"SPONSORED_BRANDS\",\n      \"adType\": \"COMPONENT\",\n      \"campaignId\": \"example-campaign-id\",\n      \"creationDateTime\": \"2020-10-15T13:33:55-07:00\",\n      \"lastUpdatedDateTime\": \"2026-03-10T09:36:30.052-07:00\",\n      \"marketplaceScope\": \"SINGLE_MARKETPLACE\",\n      \"marketplaces\": [\n        \"US\"\n      ],\n      \"state\": \"ARCHIVED\",\n      \"status\": {\n        \"deliveryReasons\": [\n          \"AD_ARCHIVED\"\n        ],\n        \"deliveryStatus\": \"NOT_DELIVERING\"\n      },\n      \"tags\": []\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Update ads",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/update/ads",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "update",
+                    "ads"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"ads\": [\n    {\n      \"adId\": \"example-ad-id\",\n      \"state\": \"PAUSED\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update ads"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/update/ads",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "update",
+                        "ads"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"ads\": [\n    {\n      \"adId\": \"example-ad-id\",\n      \"state\": \"PAUSED\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Update ads"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [\n        {\n          \"code\": \"INTERNAL_ERROR\",\n          \"message\": \"Internal server error\"\n        }\n      ],\n      \"index\": 0\n    }\n  ],\n  \"partialSuccess\": [],\n  \"success\": []\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "AdvertisingDealTargets",
+          "item": [
+            {
+              "name": "Create advertisingDealTarget",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/advertisingDealTargets/sb",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "advertisingDealTargets",
+                    "sb"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"_truncated\": true\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create advertisingDealTarget"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/advertisingDealTargets/sb",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "advertisingDealTargets",
+                        "sb"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"_truncated\": true\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create advertisingDealTarget"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"_truncated\": true\n}"
+                }
+              ]
+            },
+            {
+              "name": "Delete advertisingDealTarget",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/delete/advertisingDealTargets/sb",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "delete",
+                    "advertisingDealTargets",
+                    "sb"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"advertisingDealTargetIds\": [\n    \"sample-advertisingDealTargetIds\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Delete advertisingDealTarget"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/delete/advertisingDealTargets/sb",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "delete",
+                        "advertisingDealTargets",
+                        "sb"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"advertisingDealTargetIds\": [\n    \"sample-advertisingDealTargetIds\"\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Delete advertisingDealTarget"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [],\n      \"index\": 0\n    }\n  ],\n  \"success\": [\n    {\n      \"advertisingDealTarget\": {},\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Query advertisingDealTarget",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/advertisingDealTargets/sb",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "advertisingDealTargets",
+                    "sb"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"advertisingDealIdFilter\": {\n    \"include\": [\n      \"example-include\"\n    ]\n  },\n  \"maxResults\": 100\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query advertisingDealTarget"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/advertisingDealTargets/sb",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "advertisingDealTargets",
+                        "sb"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"advertisingDealIdFilter\": {\n    \"include\": [\n      \"example-include\"\n    ]\n  },\n  \"maxResults\": 100\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query advertisingDealTarget"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"advertisingDealTargets\": []\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "AdvertisingDeals",
+          "item": [
+            {
+              "name": "Create advertisingDeal",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/advertisingDeals/sb",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "advertisingDeals",
+                    "sb"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"advertisingDeals\": [\n    {\n      \"name\": \"Sample name\",\n      \"state\": \"DRAFT\",\n      \"startDateTime\": \"2025-01-01T00:00:00Z\",\n      \"endDateTime\": \"2025-01-01T00:00:00Z\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create advertisingDeal"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/advertisingDeals/sb",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "advertisingDeals",
+                        "sb"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"advertisingDeals\": [\n    {\n      \"name\": \"Sample name\",\n      \"state\": \"DRAFT\",\n      \"startDateTime\": \"2025-01-01T00:00:00Z\",\n      \"endDateTime\": \"2025-01-01T00:00:00Z\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create advertisingDeal"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"success\": [\n    {\n      \"advertisingDeal\": {\n        \"advertisingDealId\": \"example-advertising-deal-id\",\n        \"endDateTime\": \"2026-06-24T23:59:59-07:00\",\n        \"name\": \"Sample name\",\n        \"startDateTime\": \"2026-03-25T00:00:00-07:00\",\n        \"state\": \"DRAFT\",\n        \"status\": {\n          \"status\": \"DRAFT\"\n        }\n      },\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Delete advertisingDeal",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/delete/advertisingDeals/sb",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "delete",
+                    "advertisingDeals",
+                    "sb"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"advertisingDealIds\": [\n    \"example-advertising-deal-ids\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Delete advertisingDeal"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/delete/advertisingDeals/sb",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "delete",
+                        "advertisingDeals",
+                        "sb"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"advertisingDealIds\": [\n    \"example-advertising-deal-ids\"\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Delete advertisingDeal"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [\n        {\n          \"code\": \"FIELD_VALUE_IS_INVALID\",\n          \"fieldLocation\": \"AdvertisingDeal\",\n          \"message\": \"example-message\"\n        }\n      ],\n      \"index\": 0\n    }\n  ],\n  \"success\": []\n}"
+                }
+              ]
+            },
+            {
+              "name": "Query advertisingDeal",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/advertisingDeals/sb",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "advertisingDeals",
+                    "sb"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"advertisingDealIdFilter\": {\n    \"include\": [\n      \"example-include\"\n    ]\n  },\n  \"maxResults\": 50\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query advertisingDeal"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/advertisingDeals/sb",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "advertisingDeals",
+                        "sb"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"advertisingDealIdFilter\": {\n    \"include\": [\n      \"example-include\"\n    ]\n  },\n  \"maxResults\": 50\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query advertisingDeal"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"advertisingDeals\": []\n}"
+                }
+              ]
+            },
+            {
+              "name": "Update advertisingDeal",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/update/advertisingDeals/sb",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "update",
+                    "advertisingDeals",
+                    "sb"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"advertisingDeals\": [\n    {\n      \"advertisingDealId\": \"example-advertising-deal-id\",\n      \"state\": \"PROPOSED\",\n      \"price\": {\n        \"value\": 6023,\n        \"priceType\": \"FIXED_PRICE\"\n      }\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update advertisingDeal"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/update/advertisingDeals/sb",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "update",
+                        "advertisingDeals",
+                        "sb"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"advertisingDeals\": [\n    {\n      \"advertisingDealId\": \"example-advertising-deal-id\",\n      \"state\": \"PROPOSED\",\n      \"price\": {\n        \"value\": 6023,\n        \"priceType\": \"FIXED_PRICE\"\n      }\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Update advertisingDeal"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"success\": [\n    {\n      \"advertisingDeal\": {\n        \"advertisingDealId\": \"example-advertising-deal-id\",\n        \"endDateTime\": \"2026-06-24T23:59:59-07:00\",\n        \"name\": \"Sample name\",\n        \"price\": {\n          \"currencyCode\": \"USD\",\n          \"priceType\": \"FIXED_PRICE\",\n          \"value\": 6023.0\n        },\n        \"startDateTime\": \"2026-03-25T00:00:00-07:00\",\n        \"state\": \"PROPOSED\",\n        \"status\": {\n          \"status\": \"MODERATION_APPROVED\"\n        }\n      },\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "BrandStoreEditionPublishVersions",
+          "item": [
+            {
+              "name": "Query store edition publish versions",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/brandStoreEditionPublishVersions",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "brandStoreEditionPublishVersions"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"editionIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  },\n  \"publishStatusFilter\": {\n    \"include\": [\n      \"DRAFT\"\n    ]\n  },\n  \"storeIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query store edition publish versions"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/brandStoreEditionPublishVersions",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "brandStoreEditionPublishVersions"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"editionIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  },\n  \"publishStatusFilter\": {\n    \"include\": [\n      \"DRAFT\"\n    ]\n  },\n  \"storeIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  }\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query store edition publish versions"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"brandStoreEditionPublishVersions\": [\n    {\n      \"editionId\": \"sample-editionId\",\n      \"publishState\": \"DRAFT\",\n      \"publishStatus\": \"DRAFT\",\n      \"storeEditionPublishId\": \"sample-storeEditionPublishId\",\n      \"storeId\": \"sample-storeId\"\n    }\n  ],\n  \"nextToken\": \"sample-nextToken\"\n}"
+                }
+              ]
+            },
+            {
+              "name": "Update store edition publish versions",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/update/brandStoreEditionPublishVersions",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "update",
+                    "brandStoreEditionPublishVersions"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"brandStoreEditionPublishVersions\": [\n    {\n      \"storeEditionPublishId\": \"sample-storeEditionPublishId\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update store edition publish versions"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/update/brandStoreEditionPublishVersions",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "update",
+                        "brandStoreEditionPublishVersions"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"brandStoreEditionPublishVersions\": [\n    {\n      \"storeEditionPublishId\": \"sample-storeEditionPublishId\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Update store edition publish versions"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [],\n      \"index\": 0\n    }\n  ],\n  \"success\": [\n    {\n      \"brandStoreEditionPublishVersion\": {},\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "BrandStoreEditions",
+          "item": [
+            {
+              "name": "Retrieve brand store page content",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/brandStoreEditions?brandStoreId=&nextToken=&maxResults=",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "brandStoreEditions"
+                  ],
+                  "query": [
+                    {
+                      "key": "brandStoreId",
+                      "value": "",
+                      "disabled": false
+                    },
+                    {
+                      "key": "nextToken",
+                      "value": "",
+                      "disabled": true
+                    },
+                    {
+                      "key": "maxResults",
+                      "value": "",
+                      "disabled": true
+                    }
+                  ]
+                },
+                "description": "Retrieve brand store page content"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/brandStoreEditions?brandStoreId=&nextToken=&maxResults=",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "brandStoreEditions"
+                      ],
+                      "query": [
+                        {
+                          "key": "brandStoreId",
+                          "value": "",
+                          "disabled": false
+                        },
+                        {
+                          "key": "nextToken",
+                          "value": "",
+                          "disabled": true
+                        },
+                        {
+                          "key": "maxResults",
+                          "value": "",
+                          "disabled": true
+                        }
+                      ]
+                    },
+                    "description": "Retrieve brand store page content"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"brandStoreEditions\": [\n    {\n      \"editionId\": \"default\",\n      \"storeId\": \"example-store-id\",\n      \"editionName\": \"Sample editionName\",\n      \"storeEditionSchedule\": {}\n    },\n    {\n      \"editionId\": \"4IXVC\",\n      \"storeId\": \"example-store-id\",\n      \"editionName\": \"Sample editionName\",\n      \"storeEditionSchedule\": {}\n    },\n    {\n      \"editionId\": \"VCiEi\",\n      \"storeId\": \"example-store-id\",\n      \"editionName\": \"Sample editionName\",\n      \"storeEditionSchedule\": {\n        \"startAt\": \"example-start-at\",\n        \"endAt\": \"example-end-at\"\n      }\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "BrandStorePages",
+          "item": [
+            {
+              "name": "Retrieve brand store page content",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/brandStorePages",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "brandStorePages"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"editionIdFilter\": {\n    \"include\": [\n      \"j7Z4v\"\n    ]\n  },\n  \"maxResults\": 50,\n  \"pageIdFilter\": {\n    \"include\": [\n      \"example-include\"\n    ]\n  },\n  \"storeIdFilter\": {\n    \"include\": [\n      \"example-include\"\n    ]\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Retrieve brand store page content"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/brandStorePages",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "brandStorePages"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"editionIdFilter\": {\n    \"include\": [\n      \"j7Z4v\"\n    ]\n  },\n  \"maxResults\": 50,\n  \"pageIdFilter\": {\n    \"include\": [\n      \"example-include\"\n    ]\n  },\n  \"storeIdFilter\": {\n    \"include\": [\n      \"example-include\"\n    ]\n  }\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Retrieve brand store page content"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"_truncated\": true\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "BrandStores",
+          "item": [
+            {
+              "name": "Query brand store content",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/brandStores",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "brandStores"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"storeNameFilter\": {\n    \"include\": [\n      \"example-include\"\n    ]\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query brand store content"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/brandStores",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "brandStores"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"storeNameFilter\": {\n    \"include\": [\n      \"example-include\"\n    ]\n  }\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query brand store content"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"brandStores\": [\n    {\n      \"storeId\": \"example-store-id\",\n      \"storeName\": \"Sample storeName\",\n      \"pageInfos\": [\n        {\n          \"tag\": \"example-tag\",\n          \"title\": \"Sample title\"\n        },\n        {\n          \"tag\": \"example-tag\",\n          \"title\": \"Sample title\"\n        },\n        {\n          \"tag\": \"example-tag\",\n          \"title\": \"Sample title\"\n        },\n        {\n          \"tag\": \"example-tag\",\n          \"title\": \"Sample title\"\n        },\n        {\n          \"tag\": \"example-tag\",\n          \"title\": \"Sample title\"\n        },\n        {\n          \"tag\": \"example-tag\",\n          \"title\": \"Sample title\"\n        }\n      ]\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "BrandedKeywordsPricings",
+          "item": [
+            {
+              "name": "Create brandedKeywords pricing",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/brandedKeywordsPricings/sb",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "brandedKeywordsPricings",
+                    "sb"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"_truncated\": true\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create brandedKeywords pricing"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/brandedKeywordsPricings/sb",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "brandedKeywordsPricings",
+                        "sb"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"_truncated\": true\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create brandedKeywords pricing"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [\n        {\n          \"code\": \"DATE_TOO_SOON\",\n          \"fieldLocation\": \"BrandedKeywordsPricing\",\n          \"message\": \"Failed validation: Start date must be greater than 3 days from today.\"\n        }\n      ],\n      \"index\": 0\n    }\n  ],\n  \"success\": []\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "CampaignForecasts",
+          "item": [
+            {
+              "name": "Retrieve campaign forecast",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/retrieve/campaignForecasts/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "retrieve",
+                    "campaignForecasts",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"campaignForecastDescriptions\": [\n    {\n      \"enabledFeatures\": {\n        \"curve\": true,\n        \"metrics\": {\n          \"allMetrics\": true\n        },\n        \"campaignSettingsCache\": false\n      },\n      \"campaignId\": \"example-campaign-id\",\n      \"flightIds\": [\n        \"example-flight-ids\"\n      ]\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Retrieve campaign forecast"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/retrieve/campaignForecasts/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "retrieve",
+                        "campaignForecasts",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"campaignForecastDescriptions\": [\n    {\n      \"enabledFeatures\": {\n        \"curve\": true,\n        \"metrics\": {\n          \"allMetrics\": true\n        },\n        \"campaignSettingsCache\": false\n      },\n      \"campaignId\": \"example-campaign-id\",\n      \"flightIds\": [\n        \"example-flight-ids\"\n      ]\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Retrieve campaign forecast"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"success\": [\n    {\n      \"campaignForecast\": {\n        \"availableForecastFlights\": [\n          {\n            \"budget\": {\n              \"budgetValue\": {\n                \"monetaryBudgetValue\": {\n                  \"monetaryBudget\": {\n                    \"currencyCode\": \"JPY\",\n                    \"value\": 2.0\n                  }\n                }\n              }\n            },\n            \"endDateTime\": \"2025-01-01T00:00:00Z\",\n            \"flightId\": \"590889880665089499\",\n            \"startDateTime\": \"2025-01-01T00:00:00Z\"\n          }\n        ],\n        \"campaignDisplayName\": \"Sample campaignDisplayName\",\n        \"campaignForecastDescription\": {\n          \"campaignId\": \"577588725709359849\",\n          \"enabledFeatures\": {\n            \"campaignSettingsCache\": false,\n            \"curve\": true,\n            \"metrics\": {\n              \"allMetrics\": true\n            }\n          },\n          \"flightIds\": [\n            \"590889880665089499\"\n          ]\n        },\n        \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n        \"flightForecasts\": [\n          {\n            \"deliverInFullConfidence\": {\n              \"value\": \"UNAVAILABLE\"\n            },\n            \"flightId\": \"590889880665089499\",\n            \"metrics\": [\n              {\n                \"metric\": \"TAS\",\n                \"value\": {\n                  \"high\": 1592270000000.0,\n                  \"low\": 0.0,\n                  \"mean\": 0.0\n                }\n              }\n            ],\n            \"warnings\": [\n              {\n                \"code\": \"ORDER_FORECAST_NO_ACTIVE_LINES\"\n              }\n            ]\n          }\n        ],\n        \"hasExistingGuidance\": false\n      },\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Campaigns",
+          "item": [
+            {
+              "name": "Create campaigns",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/campaigns",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "campaigns"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"campaigns\": [\n    {\n      \"adProduct\": \"SPONSORED_PRODUCTS\",\n      \"autoCreationSettings\": {\n        \"autoCreateTargets\": true\n      },\n      \"budgets\": [\n        {\n          \"budgetType\": \"MONETARY\",\n          \"budgetValue\": {\n            \"monetaryBudgetValue\": {\n              \"monetaryBudget\": {\n                \"value\": 1\n              }\n            }\n          },\n          \"recurrenceTimePeriod\": \"DAILY\"\n        }\n      ],\n      \"countries\": [\n        \"US\"\n      ],\n      \"marketplaceScope\": \"SINGLE_MARKETPLACE\",\n      \"marketplaces\": [\n        \"US\"\n      ],\n      \"name\": \"Sample name\",\n      \"optimizations\": {\n        \"bidSettings\": {\n          \"bidStrategy\": \"MANUAL\"\n        }\n      },\n      \"portfolioId\": \"example-portfolio-id\",\n      \"startDateTime\": \"2026-05-21T04:20:11Z\",\n      \"state\": \"ENABLED\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create campaigns"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/campaigns",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "campaigns"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"campaigns\": [\n    {\n      \"adProduct\": \"SPONSORED_PRODUCTS\",\n      \"autoCreationSettings\": {\n        \"autoCreateTargets\": true\n      },\n      \"budgets\": [\n        {\n          \"budgetType\": \"MONETARY\",\n          \"budgetValue\": {\n            \"monetaryBudgetValue\": {\n              \"monetaryBudget\": {\n                \"value\": 1\n              }\n            }\n          },\n          \"recurrenceTimePeriod\": \"DAILY\"\n        }\n      ],\n      \"countries\": [\n        \"US\"\n      ],\n      \"marketplaceScope\": \"SINGLE_MARKETPLACE\",\n      \"marketplaces\": [\n        \"US\"\n      ],\n      \"name\": \"Sample name\",\n      \"optimizations\": {\n        \"bidSettings\": {\n          \"bidStrategy\": \"MANUAL\"\n        }\n      },\n      \"portfolioId\": \"example-portfolio-id\",\n      \"startDateTime\": \"2026-05-21T04:20:11Z\",\n      \"state\": \"ENABLED\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create campaigns"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [\n        {\n          \"code\": \"RESOURCE_ID_NOT_FOUND\",\n          \"message\": \"Resource not found\"\n        }\n      ],\n      \"index\": 0\n    }\n  ],\n  \"partialSuccess\": [],\n  \"success\": []\n}"
+                }
+              ]
+            },
+            {
+              "name": "Delete campaigns",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/delete/campaigns",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "delete",
+                    "campaigns"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"campaignIds\": [\n    \"example-campaign-ids\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Delete campaigns"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/delete/campaigns",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "delete",
+                        "campaigns"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"campaignIds\": [\n    \"example-campaign-ids\"\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Delete campaigns"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [\n        {\n          \"code\": \"ACTION_NOT_SUPPORTED\",\n          \"message\": \"Ended campaign cannot be updated without endDate extension\"\n        }\n      ],\n      \"index\": 0\n    }\n  ],\n  \"partialSuccess\": [],\n  \"success\": []\n}"
+                }
+              ]
+            },
+            {
+              "name": "Query campaign",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/campaigns",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "campaigns"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"stateFilter\": {\n    \"include\": [\n      \"ENABLED\",\n      \"PAUSED\"\n    ]\n  },\n  \"adProductFilter\": {\n    \"include\": [\n      \"SPONSORED_PRODUCTS\"\n    ]\n  },\n  \"maxResults\": 1000\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query campaign"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/campaigns",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "campaigns"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"stateFilter\": {\n    \"include\": [\n      \"ENABLED\",\n      \"PAUSED\"\n    ]\n  },\n  \"adProductFilter\": {\n    \"include\": [\n      \"SPONSORED_PRODUCTS\"\n    ]\n  },\n  \"maxResults\": 1000\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query campaign"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"campaigns\": [\n    {\n      \"adProduct\": \"SPONSORED_PRODUCTS\",\n      \"autoCreationSettings\": {\n        \"autoCreateTargets\": true\n      },\n      \"autoScaleGlobalCampaign\": \"MANUAL\",\n      \"budgets\": [\n        {\n          \"budgetType\": \"MONETARY\",\n          \"budgetValue\": {\n            \"monetaryBudgetValue\": {\n              \"monetaryBudget\": {\n                \"currencyCode\": \"EUR\",\n                \"value\": 3.0\n              }\n            }\n          },\n          \"recurrenceTimePeriod\": \"DAILY\"\n        }\n      ],\n      \"campaignId\": \"example-campaign-id\",\n      \"countries\": [\n        \"DE\"\n      ],\n      \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n      \"lastUpdatedDateTime\": \"2025-01-01T00:00:00Z\",\n      \"marketplaceScope\": \"SINGLE_MARKETPLACE\",\n      \"marketplaces\": [\n        \"DE\"\n      ],\n      \"name\": \"Sample name\",\n      \"optimizations\": {\n        \"bidSettings\": {\n          \"bidAdjustments\": {},\n          \"bidStrategy\": \"SALES_DOWN_ONLY\"\n        }\n      },\n      \"startDateTime\": \"2025-01-01T00:00:00Z\",\n      \"state\": \"ENABLED\",\n      \"status\": {\n        \"deliveryReasons\": [],\n        \"deliveryStatus\": \"DELIVERING\"\n      },\n      \"tags\": []\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Update campaign",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/update/campaigns",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "update",
+                    "campaigns"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"campaigns\": [\n    {\n      \"campaignId\": \"example-campaign-id\",\n      \"budgets\": [\n        {\n          \"budgetType\": \"MONETARY\",\n          \"budgetValue\": {\n            \"monetaryBudgetValue\": {\n              \"monetaryBudget\": {\n                \"value\": 55\n              }\n            }\n          },\n          \"recurrenceTimePeriod\": \"DAILY\"\n        }\n      ]\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update campaign"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/update/campaigns",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "update",
+                        "campaigns"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"campaigns\": [\n    {\n      \"campaignId\": \"example-campaign-id\",\n      \"budgets\": [\n        {\n          \"budgetType\": \"MONETARY\",\n          \"budgetValue\": {\n            \"monetaryBudgetValue\": {\n              \"monetaryBudget\": {\n                \"value\": 55\n              }\n            }\n          },\n          \"recurrenceTimePeriod\": \"DAILY\"\n        }\n      ]\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Update campaign"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [\n        {\n          \"code\": \"ACTION_NOT_SUPPORTED\",\n          \"message\": \"Operation not allowed\"\n        }\n      ],\n      \"index\": 0\n    }\n  ],\n  \"partialSuccess\": [],\n  \"success\": []\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "CommitmentSpends",
+          "item": [
+            {
+              "name": "Retrieve commitment spend",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/retrieve/commitmentSpends/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "retrieve",
+                    "commitmentSpends",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"commitmentIds\": [\n    {\n      \"commitmentId\": \"D6CPS18D84E1PBBF7S9GL3GZ\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Retrieve commitment spend"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/retrieve/commitmentSpends/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "retrieve",
+                        "commitmentSpends",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"commitmentIds\": [\n    {\n      \"commitmentId\": \"D6CPS18D84E1PBBF7S9GL3GZ\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Retrieve commitment spend"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"success\": [\n    {\n      \"commitmentSpend\": {\n        \"accruedSpendValue\": null,\n        \"accruedToDateTime\": null,\n        \"commitmentId\": {\n          \"commitmentId\": \"D6CPS18D84E1PBBF7S9GL3GZ\",\n          \"spendDimension\": null\n        },\n        \"currencyCode\": null,\n        \"projectedSpendValue\": null,\n        \"spendAtRiskValue\": null,\n        \"spendDimensionType\": \"COMMITMENT\"\n      },\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Commitments",
+          "item": [
+            {
+              "name": "List commitments",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/commitments/dsp?nextToken=&maxResults=",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "commitments",
+                    "dsp"
+                  ],
+                  "query": [
+                    {
+                      "key": "nextToken",
+                      "value": "",
+                      "disabled": true
+                    },
+                    {
+                      "key": "maxResults",
+                      "value": "",
+                      "disabled": true
+                    }
+                  ]
+                },
+                "description": "List commitments"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/commitments/dsp?nextToken=&maxResults=",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "commitments",
+                        "dsp"
+                      ],
+                      "query": [
+                        {
+                          "key": "nextToken",
+                          "value": "",
+                          "disabled": true
+                        },
+                        {
+                          "key": "maxResults",
+                          "value": "",
+                          "disabled": true
+                        }
+                      ]
+                    },
+                    "description": "List commitments"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"commitments\": [],\n  \"nextToken\": null\n}"
+                }
+              ]
+            },
+            {
+              "name": "Create commitments",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/commitments/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "commitments",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"commitments\": [\n    {\n      \"commitmentName\": \"Sample commitmentName\",\n      \"committedSpend\": 3.0,\n      \"currencyCode\": \"USD\",\n      \"dealIds\": [\n        \"example-deal-ids\",\n        \"example-deal-ids\",\n        \"example-deal-ids\"\n      ],\n      \"endDateTime\": \"2026-05-25T15:59:00Z\",\n      \"fulfillmentLevel\": \"LEVEL_5\",\n      \"spendCalculationMode\": \"MANAGER_ACCOUNT\",\n      \"startDateTime\": \"2026-05-17T16:00:00Z\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create commitments"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/commitments/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "commitments",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"commitments\": [\n    {\n      \"commitmentName\": \"Sample commitmentName\",\n      \"committedSpend\": 3.0,\n      \"currencyCode\": \"USD\",\n      \"dealIds\": [\n        \"example-deal-ids\",\n        \"example-deal-ids\",\n        \"example-deal-ids\"\n      ],\n      \"endDateTime\": \"2026-05-25T15:59:00Z\",\n      \"fulfillmentLevel\": \"LEVEL_5\",\n      \"spendCalculationMode\": \"MANAGER_ACCOUNT\",\n      \"startDateTime\": \"2026-05-17T16:00:00Z\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create commitments"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"success\": [\n    {\n      \"commitment\": {\n        \"advertiserIds\": [],\n        \"campaignIds\": [],\n        \"commitmentId\": \"1DCPS18D84E1HLM7KTM49KWY\",\n        \"commitmentName\": \"Sample commitmentName\",\n        \"committedSpend\": 3.0,\n        \"currencyCode\": \"USD\",\n        \"dealIds\": [\n          \"example-deal-ids\",\n          \"example-deal-ids\",\n          \"example-deal-ids\"\n        ],\n        \"endDateTime\": \"2026-05-25T15:59:59Z\",\n        \"fulfillmentLevel\": \"LEVEL_5\",\n        \"spendCalculationMode\": \"MANAGER_ACCOUNT\",\n        \"startDateTime\": \"2026-05-17T16:00:00Z\"\n      },\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Query commitments with filters",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/commitments/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "commitments",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"maxResults\": 50\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query commitments with filters"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/commitments/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "commitments",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"maxResults\": 50\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query commitments with filters"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"commitments\": [\n    {\n      \"advertiserIds\": [],\n      \"campaignIds\": [],\n      \"commitmentId\": \"DTCPS17F02DF4Q5X9TJ3L8J8\",\n      \"commitmentName\": \"Sample commitmentName\",\n      \"committedSpend\": 100000.0,\n      \"currencyCode\": \"USD\",\n      \"dealIds\": [],\n      \"endDateTime\": \"2025-01-01T00:00:00Z\",\n      \"fulfillmentLevel\": \"LEVEL_0\",\n      \"spendCalculationMode\": \"MANAGER_ACCOUNT\",\n      \"startDateTime\": \"2025-10-01T04:00:00Z\"\n    }\n  ],\n  \"nextToken\": null\n}"
+                }
+              ]
+            },
+            {
+              "name": "Get Commitments",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/retrieve/commitments/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "retrieve",
+                    "commitments",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"commitmentIds\": [\n    \"WLCPS18D85B5PLPQ3CD4N0FS\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Get Commitments"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/retrieve/commitments/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "retrieve",
+                        "commitments",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"commitmentIds\": [\n    \"WLCPS18D85B5PLPQ3CD4N0FS\"\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Get Commitments"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"success\": [\n    {\n      \"commitment\": {\n        \"advertiserIds\": [\n          \"example-advertiser-ids\"\n        ],\n        \"campaignIds\": [],\n        \"commitmentId\": \"WLCPS18D85B5PLPQ3CD4N0FS\",\n        \"commitmentName\": \"Sample commitmentName\",\n        \"committedSpend\": 10000.0,\n        \"currencyCode\": \"USD\",\n        \"dealIds\": [\n          \"example-deal-ids\",\n          \"example-deal-ids\"\n        ],\n        \"endDateTime\": \"2026-08-21T00:59:59Z\",\n        \"fulfillmentLevel\": \"LEVEL_5\",\n        \"spendCalculationMode\": \"ADVERTISER_ACCOUNT\",\n        \"startDateTime\": \"2026-05-21T00:00:00Z\"\n      },\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Update commitments",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/update/commitments/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "update",
+                    "commitments",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"commitments\": [\n    {\n      \"commitmentId\": \"3TCPS18D821FY2NZ79HY3Q7H\",\n      \"commitmentName\": \"Sample commitmentName\",\n      \"committedSpend\": 2.0,\n      \"currencyCode\": \"JPY\",\n      \"dealIds\": [\n        \"example-deal-ids\",\n        \"example-deal-ids\",\n        \"example-deal-ids\"\n      ],\n      \"endDateTime\": \"2026-05-18T15:59:59Z\",\n      \"fulfillmentLevel\": \"LEVEL_0\",\n      \"spendCalculationMode\": \"MANAGER_ACCOUNT\",\n      \"startDateTime\": \"2026-05-10T16:00:00Z\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update commitments"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/update/commitments/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "update",
+                        "commitments",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"commitments\": [\n    {\n      \"commitmentId\": \"3TCPS18D821FY2NZ79HY3Q7H\",\n      \"commitmentName\": \"Sample commitmentName\",\n      \"committedSpend\": 2.0,\n      \"currencyCode\": \"JPY\",\n      \"dealIds\": [\n        \"example-deal-ids\",\n        \"example-deal-ids\",\n        \"example-deal-ids\"\n      ],\n      \"endDateTime\": \"2026-05-18T15:59:59Z\",\n      \"fulfillmentLevel\": \"LEVEL_0\",\n      \"spendCalculationMode\": \"MANAGER_ACCOUNT\",\n      \"startDateTime\": \"2026-05-10T16:00:00Z\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Update commitments"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"success\": [\n    {\n      \"commitment\": {\n        \"advertiserIds\": [],\n        \"campaignIds\": [],\n        \"commitmentId\": \"3TCPS18D821FY2NZ79HY3Q7H\",\n        \"commitmentName\": \"Sample commitmentName\",\n        \"committedSpend\": 2.0,\n        \"currencyCode\": \"JPY\",\n        \"dealIds\": [\n          \"example-deal-ids\",\n          \"example-deal-ids\",\n          \"example-deal-ids\"\n        ],\n        \"endDateTime\": \"2026-05-18T15:59:59Z\",\n        \"fulfillmentLevel\": \"LEVEL_0\",\n        \"spendCalculationMode\": \"MANAGER_ACCOUNT\",\n        \"startDateTime\": \"2026-05-10T16:00:00Z\"\n      },\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "GeoLocations",
+          "item": [
+            {
+              "name": "Create Geo Location",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/geoLocations",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "geoLocations"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"geoLocations\": [\n    {\n      \"location\": {\n        \"radiusLocation\": {\n          \"coordinates\": {\n            \"latitude\": 38.897957,\n            \"longitude\": -77.03656\n          },\n          \"pointOfInterestAddress\": \"1600 Pennsylvania Ave NW, Washington, DC\",\n          \"pointOfInterestRadius\": 5,\n          \"units\": \"KILOMETERS\"\n        }\n      }\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create Geo Location"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/geoLocations",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "geoLocations"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"geoLocations\": [\n    {\n      \"location\": {\n        \"radiusLocation\": {\n          \"coordinates\": {\n            \"latitude\": 38.897957,\n            \"longitude\": -77.03656\n          },\n          \"pointOfInterestAddress\": \"1600 Pennsylvania Ave NW, Washington, DC\",\n          \"pointOfInterestRadius\": 5,\n          \"units\": \"KILOMETERS\"\n        }\n      }\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create Geo Location"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"success\": [\n    {\n      \"geoLocation\": {\n        \"geoLocationId\": \"XHvCjcKHXsKGfcKLaMKMwoh_wpHCkWzChcKHfH_CjsKFT04tYzVkNjNiZDMtZTRhMS00NGUwLWE0YzQtNzk0M2Q4Mzk0M2Qx\",\n        \"location\": {\n          \"radiusLocation\": {\n            \"coordinates\": {\n              \"latitude\": 38.897957,\n              \"longitude\": -77.03656\n            },\n            \"pointOfInterestAddress\": \"1600 Pennsylvania Ave NW, Washington, DC\",\n            \"pointOfInterestRadius\": 5,\n            \"units\": \"KILOMETERS\"\n          }\n        }\n      },\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "KeywordReservationValidations",
+          "item": [
+            {
+              "name": "Validate keyword reservation",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/keywordReservationValidations/sb",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "keywordReservationValidations",
+                    "sb"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"keywordReservationValidations\": [\n    {\n      \"keyword\": \"good go\\u00fbt\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Validate keyword reservation"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/keywordReservationValidations/sb",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "keywordReservationValidations",
+                        "sb"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"keywordReservationValidations\": [\n    {\n      \"keyword\": \"good go\\u00fbt\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Validate keyword reservation"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"success\": [\n    {\n      \"index\": 0,\n      \"keywordReservationValidation\": {\n        \"isReservable\": true,\n        \"keyword\": \"good go\\u00fbt\",\n        \"keywordReservationValidationId\": \"example-keyword-reservation-validation-id\",\n        \"reservationRejectedReason\": \"\"\n      }\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "LocationIndexes",
+          "item": [
+            {
+              "name": "Create Location Index",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/locationIndexes",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "locationIndexes"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"locationIndexes\": [\n    {\n      \"indexData\": {\n        \"directIndexValues\": {\n          \"values\": [\n            {\n              \"indexValue\": 42,\n              \"postalCode\": \"80202\"\n            },\n            {\n              \"indexValue\": 72,\n              \"postalCode\": \"80301\"\n            },\n            {\n              \"indexValue\": 13,\n              \"postalCode\": \"80424\"\n            }\n          ]\n        }\n      },\n      \"indexName\": \"us-east-locations\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create Location Index"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/locationIndexes",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "locationIndexes"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"locationIndexes\": [\n    {\n      \"indexData\": {\n        \"directIndexValues\": {\n          \"values\": [\n            {\n              \"indexValue\": 42,\n              \"postalCode\": \"80202\"\n            },\n            {\n              \"indexValue\": 72,\n              \"postalCode\": \"80301\"\n            },\n            {\n              \"indexValue\": 13,\n              \"postalCode\": \"80424\"\n            }\n          ]\n        }\n      },\n      \"indexName\": \"us-east-locations\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create Location Index"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"success\": [\n    {\n      \"index\": 0,\n      \"locationIndex\": {\n        \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n        \"indexId\": \"518f53e3-1739-4644-8f9a-a0211a6188d0\",\n        \"indexName\": \"us-east-locations\",\n        \"lastUpdatedDateTime\": \"2025-01-01T00:00:00Z\",\n        \"status\": \"PENDING\"\n      }\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "List Location Index",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/locationIndexes?nextToken=&maxResults=",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "locationIndexes"
+                  ],
+                  "query": [
+                    {
+                      "key": "nextToken",
+                      "value": "",
+                      "disabled": true
+                    },
+                    {
+                      "key": "maxResults",
+                      "value": "",
+                      "disabled": true
+                    }
+                  ]
+                },
+                "description": "List Location Index"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/locationIndexes?nextToken=&maxResults=",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "locationIndexes"
+                      ],
+                      "query": [
+                        {
+                          "key": "nextToken",
+                          "value": "",
+                          "disabled": true
+                        },
+                        {
+                          "key": "maxResults",
+                          "value": "",
+                          "disabled": true
+                        }
+                      ]
+                    },
+                    "description": "List Location Index"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"locationIndexes\": [],\n  \"nextToken\": null\n}"
+                }
+              ]
+            },
+            {
+              "name": "Retrieve Location Index",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/retrieve/locationIndexes",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "retrieve",
+                    "locationIndexes"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"indexIds\": [\n    \"518f53e3-1739-4644-8f9a-a0211a6188d0\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Retrieve Location Index"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/retrieve/locationIndexes",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "retrieve",
+                        "locationIndexes"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"indexIds\": [\n    \"518f53e3-1739-4644-8f9a-a0211a6188d0\"\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Retrieve Location Index"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"success\": [\n    {\n      \"index\": 0,\n      \"locationIndex\": {\n        \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n        \"indexId\": \"518f53e3-1739-4644-8f9a-a0211a6188d0\",\n        \"indexName\": \"us-east-locations\",\n        \"lastUpdatedDateTime\": \"2025-01-01T00:00:00Z\",\n        \"status\": \"ENABLED\"\n      }\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Update Location Index",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/update/locationIndexes",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "update",
+                    "locationIndexes"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"locationIndexes\": [\n    {\n      \"indexData\": {\n        \"directIndexValues\": {\n          \"values\": [\n            {\n              \"indexValue\": 55,\n              \"postalCode\": \"80202\"\n            },\n            {\n              \"indexValue\": 80,\n              \"postalCode\": \"80301\"\n            },\n            {\n              \"indexValue\": 20,\n              \"postalCode\": \"80424\"\n            }\n          ]\n        }\n      },\n      \"indexId\": \"518f53e3-1739-4644-8f9a-a0211a6188d0\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update Location Index"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/update/locationIndexes",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "update",
+                        "locationIndexes"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"locationIndexes\": [\n    {\n      \"indexData\": {\n        \"directIndexValues\": {\n          \"values\": [\n            {\n              \"indexValue\": 55,\n              \"postalCode\": \"80202\"\n            },\n            {\n              \"indexValue\": 80,\n              \"postalCode\": \"80301\"\n            },\n            {\n              \"indexValue\": 20,\n              \"postalCode\": \"80424\"\n            }\n          ]\n        }\n      },\n      \"indexId\": \"518f53e3-1739-4644-8f9a-a0211a6188d0\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Update Location Index"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"success\": [\n    {\n      \"index\": 0,\n      \"locationIndex\": {\n        \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n        \"indexId\": \"518f53e3-1739-4644-8f9a-a0211a6188d0\",\n        \"indexName\": \"us-east-locations\",\n        \"lastUpdatedDateTime\": \"2025-01-01T00:00:00Z\",\n        \"status\": \"PENDING\"\n      }\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "RecommendationTypes",
+          "item": [
+            {
+              "name": "Query RecommendationTypes",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/recommendationTypes/sb",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "recommendationTypes",
+                    "sb"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query RecommendationTypes"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/recommendationTypes/sb",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "recommendationTypes",
+                        "sb"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query RecommendationTypes"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"recommendationTypes\": [\n    {\n      \"recommendationTypeId\": \"BRANDED_KEYWORD\",\n      \"recommendationTypeTitle\": \"Sample recommendationTypeTitle\"\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Recommendations",
+          "item": [
+            {
+              "name": "Create recommendations",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/recommendations/sb",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "recommendations",
+                    "sb"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"recommendations\": [\n    {\n      \"recommendationType\": \"BRANDED_KEYWORD\",\n      \"recommendationTypeDetails\": {\n        \"brandedKeywordRecommendationTypeDetails\": {\n          \"brandAlternateId\": [\n            {\n              \"alternateBrandId\": \"A38O0QIZW7IUPY\",\n              \"alternateBrandIdType\": \"BRAND_REGISTRY\"\n            }\n          ]\n        }\n      }\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create recommendations"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/recommendations/sb",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "recommendations",
+                        "sb"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"recommendations\": [\n    {\n      \"recommendationType\": \"BRANDED_KEYWORD\",\n      \"recommendationTypeDetails\": {\n        \"brandedKeywordRecommendationTypeDetails\": {\n          \"brandAlternateId\": [\n            {\n              \"alternateBrandId\": \"A38O0QIZW7IUPY\",\n              \"alternateBrandIdType\": \"BRAND_REGISTRY\"\n            }\n          ]\n        }\n      }\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create recommendations"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"success\": [\n    {\n      \"index\": 0,\n      \"recommendation\": {\n        \"recommendationId\": \"example-recommendation-id\",\n        \"recommendationType\": \"BRANDED_KEYWORD\",\n        \"recommendationTypeDetails\": {\n          \"brandedKeywordRecommendationTypeDetails\": {\n            \"brandAlternateId\": [\n              {\n                \"alternateBrandId\": \"A38O0QIZW7IUPY\",\n                \"alternateBrandIdType\": \"BRAND_REGISTRY\"\n              }\n            ]\n          }\n        },\n        \"recommendedObjects\": [\n          {\n            \"recommendedObjectSettings\": {\n              \"brandedKeywordList\": {\n                \"brandedKeyword\": [\n                  {\n                    \"brandAlternateId\": {\n                      \"alternateBrandId\": \"A38O0QIZW7IUPY\",\n                      \"alternateBrandIdType\": \"BRAND_REGISTRY\"\n                    },\n                    \"keyword\": \"urboria orivon\"\n                  },\n                  {\n                    \"brandAlternateId\": {\n                      \"alternateBrandId\": \"A38O0QIZW7IUPY\",\n                      \"alternateBrandIdType\": \"BRAND_REGISTRY\"\n                    },\n                    \"keyword\": \"urboria orivon mug\"\n                  },\n                  {\n                    \"brandAlternateId\": {\n                      \"alternateBrandId\": \"A38O0QIZW7IUPY\",\n                      \"alternateBrandIdType\": \"BRAND_REGISTRY\"\n                    },\n                    \"keyword\": \"urboria orivon panda mug\"\n                  }\n                ]\n              }\n            }\n          }\n        ]\n      }\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "ReservedTargetPricings",
+          "item": [
+            {
+              "name": "Create reservedTarget pricing",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/reservedTargetPricings/sb",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "reservedTargetPricings",
+                    "sb"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"reservedTargetPricings\": [\n    {\n      \"targetPricingId\": \"sample-targetPricingId\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create reservedTarget pricing"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/reservedTargetPricings/sb",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "reservedTargetPricings",
+                        "sb"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"reservedTargetPricings\": [\n    {\n      \"targetPricingId\": \"sample-targetPricingId\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create reservedTarget pricing"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [],\n      \"index\": 0\n    }\n  ],\n  \"success\": [\n    {\n      \"index\": 0,\n      \"reservedTargetPricing\": {}\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Targets",
+          "item": [
+            {
+              "name": "Create target",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/targets",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "targets"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"targets\": [\n    {\n      \"adGroupId\": \"example-ad-group-id\",\n      \"adProduct\": \"SPONSORED_TELEVISION\",\n      \"negative\": false,\n      \"state\": \"ENABLED\",\n      \"targetDetails\": {\n        \"audienceTarget\": {\n          \"audienceId\": {\n            \"defaultValue\": \"\"\n          }\n        }\n      },\n      \"targetType\": \"AUDIENCE\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create target"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/targets",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "targets"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"targets\": [\n    {\n      \"adGroupId\": \"example-ad-group-id\",\n      \"adProduct\": \"SPONSORED_TELEVISION\",\n      \"negative\": false,\n      \"state\": \"ENABLED\",\n      \"targetDetails\": {\n        \"audienceTarget\": {\n          \"audienceId\": {\n            \"defaultValue\": \"\"\n          }\n        }\n      },\n      \"targetType\": \"AUDIENCE\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create target"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [\n        {\n          \"code\": \"FIELD_VALUE_IS_INVALID\",\n          \"message\": \"Invalid Audience Id: \"\n        }\n      ],\n      \"index\": 0\n    }\n  ],\n  \"partialSuccess\": [],\n  \"success\": []\n}"
+                }
+              ]
+            },
+            {
+              "name": "Delete target",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/delete/targets",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "delete",
+                    "targets"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"targetIds\": [\n    \"example-target-ids\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Delete target"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/delete/targets",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "delete",
+                        "targets"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"targetIds\": [\n    \"example-target-ids\"\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Delete target"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [\n        {\n          \"code\": \"BAD_REQUEST\",\n          \"message\": \"Invalid record id provided in Delete request. Failed to retrieve the existing record using the record id.\"\n        }\n      ],\n      \"index\": 0\n    }\n  ],\n  \"partialSuccess\": [],\n  \"success\": []\n}"
+                }
+              ]
+            },
+            {
+              "name": "List target",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/targets",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "targets"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"stateFilter\": {\n    \"include\": [\n      \"ENABLED\",\n      \"PAUSED\"\n    ]\n  },\n  \"adProductFilter\": {\n    \"include\": [\n      \"SPONSORED_PRODUCTS\"\n    ]\n  },\n  \"maxResults\": 1000,\n  \"negativeFilter\": {\n    \"include\": [\n      false\n    ]\n  },\n  \"targetTypeFilter\": {\n    \"include\": [\n      \"KEYWORD\"\n    ]\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "List target"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/targets",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "targets"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"stateFilter\": {\n    \"include\": [\n      \"ENABLED\",\n      \"PAUSED\"\n    ]\n  },\n  \"adProductFilter\": {\n    \"include\": [\n      \"SPONSORED_PRODUCTS\"\n    ]\n  },\n  \"maxResults\": 1000,\n  \"negativeFilter\": {\n    \"include\": [\n      false\n    ]\n  },\n  \"targetTypeFilter\": {\n    \"include\": [\n      \"KEYWORD\"\n    ]\n  }\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "List target"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"targets\": [\n    {\n      \"adGroupId\": \"example-ad-group-id\",\n      \"adProduct\": \"SPONSORED_PRODUCTS\",\n      \"campaignId\": \"example-campaign-id\",\n      \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n      \"lastUpdatedDateTime\": \"2025-01-01T00:00:00Z\",\n      \"marketplaceScope\": \"SINGLE_MARKETPLACE\",\n      \"marketplaces\": [\n        \"JP\"\n      ],\n      \"negative\": false,\n      \"state\": \"ENABLED\",\n      \"status\": {\n        \"deliveryReasons\": [],\n        \"deliveryStatus\": \"DELIVERING\"\n      },\n      \"tags\": [],\n      \"targetDetails\": {\n        \"keywordTarget\": {\n          \"keyword\": \"(_targeting_auto_)\",\n          \"matchType\": \"BROAD\"\n        }\n      },\n      \"targetId\": \"example-target-id\",\n      \"targetLevel\": \"AD_GROUP\",\n      \"targetType\": \"KEYWORD\"\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Update target",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/update/targets",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "update",
+                    "targets"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"targets\": [\n    {\n      \"targetId\": \"\",\n      \"state\": \"PAUSED\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update target"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/update/targets",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "update",
+                        "targets"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"targets\": [\n    {\n      \"targetId\": \"\",\n      \"state\": \"PAUSED\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Update target"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [\n        {\n          \"code\": \"BAD_REQUEST\",\n          \"message\": \"Invalid record id provided in Update request. Failed to retrieve the existing record using the record id.\"\n        }\n      ],\n      \"index\": 0\n    }\n  ],\n  \"partialSuccess\": [],\n  \"success\": []\n}"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Unified API \u2014 Beta",
+      "item": [
+        {
+          "name": "AccountCombinationInvitations",
+          "item": [
+            {
+              "name": "Create Account Combination Invitation",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/accountCombinationInvitations",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "accountCombinationInvitations"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"accountCombinationInvitations\": [\n    {\n      \"accountsToCombine\": []\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create Account Combination Invitation"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/accountCombinationInvitations",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "accountCombinationInvitations"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"accountCombinationInvitations\": [\n    {\n      \"accountsToCombine\": []\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create Account Combination Invitation"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [],\n      \"index\": 0\n    }\n  ],\n  \"success\": [\n    {\n      \"accountCombinationInvitation\": {},\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Query Account Combination Invitation",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/accountCombinationInvitations",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "accountCombinationInvitations"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"maxResults\": 1,\n  \"nextToken\": \"sample-nextToken\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query Account Combination Invitation"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/accountCombinationInvitations",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "accountCombinationInvitations"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"maxResults\": 1,\n  \"nextToken\": \"sample-nextToken\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query Account Combination Invitation"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"accountCombinationInvitations\": [\n    {\n      \"accountCombinationInvitationId\": \"sample-accountCombinationInvitationId\",\n      \"accountsToCombine\": [],\n      \"statusMessage\": \"sample-statusMessage\"\n    }\n  ],\n  \"nextToken\": \"sample-nextToken\"\n}"
+                }
+              ]
+            },
+            {
+              "name": "Update Account Combination Invitation",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/update/accountCombinationInvitations",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "update",
+                    "accountCombinationInvitations"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"accountCombinationInvitations\": [\n    {\n      \"accountCombinationInvitationId\": \"sample-accountCombinationInvitationId\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update Account Combination Invitation"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/update/accountCombinationInvitations",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "update",
+                        "accountCombinationInvitations"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"accountCombinationInvitations\": [\n    {\n      \"accountCombinationInvitationId\": \"sample-accountCombinationInvitationId\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Update Account Combination Invitation"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [],\n      \"index\": 0\n    }\n  ],\n  \"success\": [\n    {\n      \"accountCombinationInvitation\": {},\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "AdvertiserAccounts",
+          "item": [
+            {
+              "name": "Create advertiser accounts",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/advertiserAccounts",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "advertiserAccounts"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"_truncated\": true\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create advertiser accounts"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/advertiserAccounts",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "advertiserAccounts"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"_truncated\": true\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create advertiser accounts"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"_truncated\": true\n}"
+                }
+              ]
+            },
+            {
+              "name": "List advertiser accounts",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/advertiserAccounts",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "advertiserAccounts"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "List advertiser accounts"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/advertiserAccounts",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "advertiserAccounts"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "List advertiser accounts"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"advertiserAccounts\": [\n    {\n      \"advertiserAccountId\": \"example-advertiser-account-id\",\n      \"alternateIds\": [\n        {\n          \"countryCode\": \"US\",\n          \"entityId\": \"example-entity-id\",\n          \"profileId\": \"example-profile-id\"\n        }\n      ],\n      \"displayName\": \"Sample displayName\",\n      \"isGlobalAccount\": true\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Update advertiser accounts",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/update/advertiserAccounts",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "update",
+                    "advertiserAccounts"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "\"example-value\"",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update advertiser accounts"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/update/advertiserAccounts",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "update",
+                        "advertiserAccounts"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "\"example-value\"",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Update advertiser accounts"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "\"example-value\""
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "AdvertiserProductGroupEligibilities",
+          "item": [
+            {
+              "name": "Create request for specific advertiser product group eligibility",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/advertiserProductGroupEligibilities",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "advertiserProductGroupEligibilities"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"advertiserProductGroupEligibilities\": [\n    {\n      \"adProductGroup\": \"ADSP\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create request for specific advertiser product group eligibility"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/advertiserProductGroupEligibilities",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "advertiserProductGroupEligibilities"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"advertiserProductGroupEligibilities\": [\n    {\n      \"adProductGroup\": \"ADSP\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create request for specific advertiser product group eligibility"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"success\": [\n    {\n      \"advertiserProductGroupEligibility\": {\n        \"adProductGroup\": \"ADSP\",\n        \"advertiserAccountId\": \"example-advertiser-account-id\",\n        \"advertiserProductGroupEligibilityId\": \"example-advertiser-product-group-eligibility-id\",\n        \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n        \"rejectedReasonDetail\": null,\n        \"status\": \"PENDING\"\n      },\n      \"index\": null\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Query Advertiser Product Group Eligibility",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/advertiserProductGroupEligibilities",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "advertiserProductGroupEligibilities"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"maxResults\": 0,\n  \"nextToken\": \"sample-nextToken\",\n  \"statusFilter\": {\n    \"include\": [\n      \"APPROVED\"\n    ]\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query Advertiser Product Group Eligibility"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/advertiserProductGroupEligibilities",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "advertiserProductGroupEligibilities"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"maxResults\": 0,\n  \"nextToken\": \"sample-nextToken\",\n  \"statusFilter\": {\n    \"include\": [\n      \"APPROVED\"\n    ]\n  }\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query Advertiser Product Group Eligibility"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"advertiserProductGroupEligibilities\": [\n    {\n      \"adProductGroup\": \"ADSP\",\n      \"advertiserAccountId\": \"sample-advertiserAccountId\",\n      \"advertiserProductGroupEligibilityId\": \"sample-advertiserProductGroupEligibilityId\",\n      \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n      \"status\": \"APPROVED\"\n    }\n  ],\n  \"nextToken\": \"sample-nextToken\"\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "AdvertisingDeals",
+          "item": [
+            {
+              "name": "Create advertising deals",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/advertisingDeals/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "advertisingDeals",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"advertisingDeals\": [\n    {\n      \"name\": \"Sample name\",\n      \"exchangeDealId\": \"sample-exchange-deal-id-1\",\n      \"exchangeId\": \"1918\",\n      \"adProduct\": \"AMAZON_DSP\",\n      \"dealType\": \"PRIVATE_AUCTION\",\n      \"startDateTime\": \"2027-01-01T00:00:00Z\",\n      \"endDateTime\": \"2027-12-31T23:59:59Z\",\n      \"terms\": {\n        \"price\": {\n          \"currencyCode\": \"USD\",\n          \"value\": 5.0,\n          \"priceType\": \"FIXED_CPM\"\n        },\n        \"guaranteed\": false,\n        \"marketplaceDeal\": false\n      }\n    },\n    {\n      \"name\": \"Sample name\",\n      \"exchangeDealId\": \"sample-exchange-deal-id-2\",\n      \"exchangeId\": \"1918\",\n      \"adProduct\": \"AMAZON_DSP\",\n      \"dealType\": \"PRIVATE_AUCTION\",\n      \"startDateTime\": \"2027-01-01T00:00:00Z\",\n      \"endDateTime\": \"2027-12-31T23:59:59Z\",\n      \"terms\": {\n        \"price\": {\n          \"currencyCode\": \"USD\",\n          \"value\": 5.0,\n          \"priceType\": \"FIXED_CPM\"\n        },\n        \"guaranteed\": false,\n        \"marketplaceDeal\": false\n      }\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create advertising deals"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/advertisingDeals/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "advertisingDeals",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"advertisingDeals\": [\n    {\n      \"name\": \"Sample name\",\n      \"exchangeDealId\": \"sample-exchange-deal-id-1\",\n      \"exchangeId\": \"1918\",\n      \"adProduct\": \"AMAZON_DSP\",\n      \"dealType\": \"PRIVATE_AUCTION\",\n      \"startDateTime\": \"2027-01-01T00:00:00Z\",\n      \"endDateTime\": \"2027-12-31T23:59:59Z\",\n      \"terms\": {\n        \"price\": {\n          \"currencyCode\": \"USD\",\n          \"value\": 5.0,\n          \"priceType\": \"FIXED_CPM\"\n        },\n        \"guaranteed\": false,\n        \"marketplaceDeal\": false\n      }\n    },\n    {\n      \"name\": \"Sample name\",\n      \"exchangeDealId\": \"sample-exchange-deal-id-2\",\n      \"exchangeId\": \"1918\",\n      \"adProduct\": \"AMAZON_DSP\",\n      \"dealType\": \"PRIVATE_AUCTION\",\n      \"startDateTime\": \"2027-01-01T00:00:00Z\",\n      \"endDateTime\": \"2027-12-31T23:59:59Z\",\n      \"terms\": {\n        \"price\": {\n          \"currencyCode\": \"USD\",\n          \"value\": 5.0,\n          \"priceType\": \"FIXED_CPM\"\n        },\n        \"guaranteed\": false,\n        \"marketplaceDeal\": false\n      }\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create advertising deals"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [\n        {\n          \"code\": \"DUPLICATE_DEAL_ID\",\n          \"fieldLocation\": null,\n          \"message\": \"Deal Id already exists in the entity\"\n        }\n      ],\n      \"index\": 1\n    }\n  ],\n  \"success\": [\n    {\n      \"advertisingDeal\": {\n        \"adProduct\": \"AMAZON_DSP\",\n        \"advertisingDealId\": \"example-advertising-deal-id\",\n        \"creationDateTime\": null,\n        \"customPublisherDescription\": null,\n        \"dealType\": \"PREFERRED\",\n        \"endDateTime\": \"2027-12-31T23:59:59Z\",\n        \"exchangeDealId\": \"sample-exchange-deal-id-1\",\n        \"exchangeId\": \"1918\",\n        \"inventoryTypes\": null,\n        \"lastUpdatedDateTime\": null,\n        \"name\": \"Sample name\",\n        \"startDateTime\": \"2027-01-01T00:00:00Z\",\n        \"status\": {\n          \"status\": \"ACTIVE\",\n          \"statusDateTime\": null,\n          \"statusReason\": null\n        },\n        \"terms\": {\n          \"budget\": null,\n          \"guaranteed\": false,\n          \"impressions\": null,\n          \"marketplaceDeal\": null,\n          \"price\": {\n            \"currencyCode\": \"USD\",\n            \"priceType\": \"FIXED_CPM\",\n            \"value\": 5.0\n          },\n          \"shareOfVoicePercentage\": null\n        }\n      },\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Query advertising deals with filters",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/advertisingDeals/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "advertisingDeals",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"advertisingDealIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  },\n  \"countryCodeFilter\": {\n    \"include\": [\n      \"AD\"\n    ]\n  },\n  \"creationDateTimeRangeFilter\": {\n    \"include\": [\n      {}\n    ]\n  },\n  \"dealTypeFilter\": {\n    \"include\": [\n      \"PREFERRED\"\n    ]\n  },\n  \"endDateTimeRangeFilter\": {\n    \"include\": [\n      {}\n    ]\n  },\n  \"exchangeDealIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query advertising deals with filters"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/advertisingDeals/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "advertisingDeals",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"advertisingDealIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  },\n  \"countryCodeFilter\": {\n    \"include\": [\n      \"AD\"\n    ]\n  },\n  \"creationDateTimeRangeFilter\": {\n    \"include\": [\n      {}\n    ]\n  },\n  \"dealTypeFilter\": {\n    \"include\": [\n      \"PREFERRED\"\n    ]\n  },\n  \"endDateTimeRangeFilter\": {\n    \"include\": [\n      {}\n    ]\n  },\n  \"exchangeDealIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  }\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query advertising deals with filters"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"advertisingDeals\": [\n    {\n      \"adProduct\": \"AMAZON_DSP\",\n      \"advertisingDealId\": \"sample-advertisingDealId\",\n      \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n      \"dealType\": \"PREFERRED\",\n      \"endDateTime\": \"2025-01-01T00:00:00Z\",\n      \"name\": \"sample-name\",\n      \"startDateTime\": \"2025-01-01T00:00:00Z\",\n      \"status\": {}\n    }\n  ],\n  \"nextToken\": \"sample-nextToken\",\n  \"totalResults\": 0\n}"
+                }
+              ]
+            },
+            {
+              "name": "Update advertising deals",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/update/advertisingDeals/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "update",
+                    "advertisingDeals",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"advertisingDeals\": [\n    {\n      \"advertisingDealId\": \"example-advertising-deal-id\",\n      \"name\": \"Sample name\",\n      \"startDateTime\": \"2026-07-25T07:17:39Z\",\n      \"endDateTime\": \"2026-08-24T07:17:39Z\",\n      \"terms\": {\n        \"price\": {\n          \"currencyCode\": \"USD\",\n          \"value\": 5.0,\n          \"priceType\": \"FLOOR_RATE\"\n        }\n      }\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update advertising deals"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/update/advertisingDeals/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "update",
+                        "advertisingDeals",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"advertisingDeals\": [\n    {\n      \"advertisingDealId\": \"example-advertising-deal-id\",\n      \"name\": \"Sample name\",\n      \"startDateTime\": \"2026-07-25T07:17:39Z\",\n      \"endDateTime\": \"2026-08-24T07:17:39Z\",\n      \"terms\": {\n        \"price\": {\n          \"currencyCode\": \"USD\",\n          \"value\": 5.0,\n          \"priceType\": \"FLOOR_RATE\"\n        }\n      }\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Update advertising deals"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"success\": [\n    {\n      \"advertisingDeal\": {\n        \"adProduct\": \"AMAZON_DSP\",\n        \"advertisingDealId\": \"example-advertising-deal-id\",\n        \"dealType\": \"PRIVATE_AUCTION\",\n        \"endDateTime\": \"2026-08-24T07:17:39Z\",\n        \"exchangeDealId\": \"example-exchange-deal-id\",\n        \"exchangeId\": \"1918\",\n        \"name\": \"Sample name\",\n        \"startDateTime\": \"2026-07-25T07:17:39Z\",\n        \"status\": {\n          \"status\": \"SCHEDULED\"\n        },\n        \"terms\": {\n          \"guaranteed\": false,\n          \"price\": {\n            \"currencyCode\": \"USD\",\n            \"priceType\": \"FLOOR_RATE\",\n            \"value\": 5.0\n          }\n        }\n      },\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "BrandStorePages",
+          "item": [
+            {
+              "name": "Update brand store page content",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/update/brandStorePages",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "update",
+                    "brandStorePages"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"_truncated\": true\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update brand store page content"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/update/brandStorePages",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "update",
+                        "brandStorePages"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"_truncated\": true\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Update brand store page content"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"_truncated\": true\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "BuyerSeats",
+          "item": [
+            {
+              "name": "List buyer seats",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/buyerSeats/dsp?buyerSeatType=&exchangeId=&nextToken=&maxResults=",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "buyerSeats",
+                    "dsp"
+                  ],
+                  "query": [
+                    {
+                      "key": "buyerSeatType",
+                      "value": "",
+                      "disabled": true,
+                      "description": "\n| BuyerSeatType | Description |\n| --- | --- |\n| `DEAL_CREATION` | The ID for deal providers to identify the buyer seat when creating deals. |\n| `SPEND_TRACKING` | The ID passed to exchanges to enable buyer recognition within auctions. This can be used for both real-time decision making and offline reporting. |\n"
+                    },
+                    {
+                      "key": "exchangeId",
+                      "value": "",
+                      "disabled": true
+                    },
+                    {
+                      "key": "nextToken",
+                      "value": "",
+                      "disabled": true
+                    },
+                    {
+                      "key": "maxResults",
+                      "value": "",
+                      "disabled": true
+                    }
+                  ]
+                },
+                "description": "List buyer seats"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/buyerSeats/dsp?buyerSeatType=&exchangeId=&nextToken=&maxResults=",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "buyerSeats",
+                        "dsp"
+                      ],
+                      "query": [
+                        {
+                          "key": "buyerSeatType",
+                          "value": "",
+                          "disabled": true,
+                          "description": "\n| BuyerSeatType | Description |\n| --- | --- |\n| `DEAL_CREATION` | The ID for deal providers to identify the buyer seat when creating deals. |\n| `SPEND_TRACKING` | The ID passed to exchanges to enable buyer recognition within auctions. This can be used for both real-time decision making and offline reporting. |\n"
+                        },
+                        {
+                          "key": "exchangeId",
+                          "value": "",
+                          "disabled": true
+                        },
+                        {
+                          "key": "nextToken",
+                          "value": "",
+                          "disabled": true
+                        },
+                        {
+                          "key": "maxResults",
+                          "value": "",
+                          "disabled": true
+                        }
+                      ]
+                    },
+                    "description": "List buyer seats"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"buyerSeats\": [\n    {\n      \"buyerSeatId\": \"sample-buyerSeatId\",\n      \"seatType\": \"DEAL_CREATION\"\n    }\n  ],\n  \"nextToken\": \"sample-nextToken\"\n}"
+                }
+              ]
+            },
+            {
+              "name": "Create buyer seats for advertisers",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/buyerSeats/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "buyerSeats",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"buyerSeats\": [\n    {\n      \"seatType\": \"DEAL_CREATION\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create buyer seats for advertisers"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/buyerSeats/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "buyerSeats",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"buyerSeats\": [\n    {\n      \"seatType\": \"DEAL_CREATION\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create buyer seats for advertisers"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [],\n      \"index\": 0\n    }\n  ],\n  \"success\": [\n    {\n      \"buyerSeat\": {},\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "DealAdvertiserAccessEntries",
+          "item": [
+            {
+              "name": "Add advertisers to a deal advertiser access list",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/dealAdvertiserAccessEntries/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "dealAdvertiserAccessEntries",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"dealAdvertiserAccessEntries\": [\n    {\n      \"advertiserId\": \"sample-advertiserId\",\n      \"dealAdvertiserAccessId\": \"sample-dealAdvertiserAccessId\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Add advertisers to a deal advertiser access list"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/dealAdvertiserAccessEntries/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "dealAdvertiserAccessEntries",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"dealAdvertiserAccessEntries\": [\n    {\n      \"advertiserId\": \"sample-advertiserId\",\n      \"dealAdvertiserAccessId\": \"sample-dealAdvertiserAccessId\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Add advertisers to a deal advertiser access list"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [],\n      \"index\": 0\n    }\n  ],\n  \"success\": [\n    {\n      \"dealAdvertiserAccessEntry\": {},\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Remove advertisers from a deal advertiser access list",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/delete/dealAdvertiserAccessEntries/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "delete",
+                    "dealAdvertiserAccessEntries",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"dealAdvertiserAccessEntryIds\": [\n    \"sample-dealAdvertiserAccessEntryIds\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Remove advertisers from a deal advertiser access list"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/delete/dealAdvertiserAccessEntries/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "delete",
+                        "dealAdvertiserAccessEntries",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"dealAdvertiserAccessEntryIds\": [\n    \"sample-dealAdvertiserAccessEntryIds\"\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Remove advertisers from a deal advertiser access list"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [],\n      \"index\": 0\n    }\n  ],\n  \"success\": [\n    {\n      \"dealAdvertiserAccessEntry\": {},\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Query advertiser entries for a deal advertiser access record",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/dealAdvertiserAccessEntries/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "dealAdvertiserAccessEntries",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"dealAdvertiserAccessIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query advertiser entries for a deal advertiser access record"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/dealAdvertiserAccessEntries/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "dealAdvertiserAccessEntries",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"dealAdvertiserAccessIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  }\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query advertiser entries for a deal advertiser access record"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"dealAdvertiserAccessEntries\": [\n    {\n      \"advertiserId\": \"sample-advertiserId\",\n      \"dealAdvertiserAccessEntryId\": \"sample-dealAdvertiserAccessEntryId\",\n      \"dealAdvertiserAccessId\": \"sample-dealAdvertiserAccessId\"\n    }\n  ],\n  \"nextToken\": \"sample-nextToken\",\n  \"totalResults\": 0\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "DealAdvertiserAccesses",
+          "item": [
+            {
+              "name": "Create a deal advertiser access record with a strategy (ALLOW or BLOCK)",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/dealAdvertiserAccesses/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "dealAdvertiserAccesses",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"dealAdvertiserAccesses\": [\n    {\n      \"advertisingDealId\": \"sample-advertisingDealId\",\n      \"strategy\": \"ALLOW\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create a deal advertiser access record with a strategy (ALLOW or BLOCK)"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/dealAdvertiserAccesses/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "dealAdvertiserAccesses",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"dealAdvertiserAccesses\": [\n    {\n      \"advertisingDealId\": \"sample-advertisingDealId\",\n      \"strategy\": \"ALLOW\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create a deal advertiser access record with a strategy (ALLOW or BLOCK)"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [],\n      \"index\": 0\n    }\n  ],\n  \"success\": [\n    {\n      \"dealAdvertiserAccess\": {},\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Delete a deal advertiser access record and all associated entries",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/delete/dealAdvertiserAccesses/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "delete",
+                    "dealAdvertiserAccesses",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"dealAdvertiserAccessIds\": [\n    \"sample-dealAdvertiserAccessIds\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Delete a deal advertiser access record and all associated entries"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/delete/dealAdvertiserAccesses/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "delete",
+                        "dealAdvertiserAccesses",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"dealAdvertiserAccessIds\": [\n    \"sample-dealAdvertiserAccessIds\"\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Delete a deal advertiser access record and all associated entries"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [],\n      \"index\": 0\n    }\n  ],\n  \"success\": [\n    {\n      \"dealAdvertiserAccess\": {},\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Retrieve a deal advertiser access record by ID",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/retrieve/dealAdvertiserAccesses/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "retrieve",
+                    "dealAdvertiserAccesses",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"dealAdvertiserAccessIds\": [\n    \"sample-dealAdvertiserAccessIds\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Retrieve a deal advertiser access record by ID"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/retrieve/dealAdvertiserAccesses/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "retrieve",
+                        "dealAdvertiserAccesses",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"dealAdvertiserAccessIds\": [\n    \"sample-dealAdvertiserAccessIds\"\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Retrieve a deal advertiser access record by ID"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [],\n      \"index\": 0\n    }\n  ],\n  \"success\": [\n    {\n      \"dealAdvertiserAccess\": {},\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "DealAvailses",
+          "item": [
+            {
+              "name": "D S P Query Deal Avails",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/dealAvailses/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "dealAvailses",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"advertisingDealIdFilter\": {\n    \"include\": [\n      \"example-include\"\n    ]\n  },\n  \"maxResults\": 50\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "D S P Query Deal Avails"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/dealAvailses/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "dealAvailses",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"advertisingDealIdFilter\": {\n    \"include\": [\n      \"example-include\"\n    ]\n  },\n  \"maxResults\": 50\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "D S P Query Deal Avails"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"dealAvailses\": [\n    {\n      \"advertisingDealId\": \"example-advertising-deal-id\",\n      \"appId\": null,\n      \"audienceId\": null,\n      \"countryCode\": null,\n      \"creativeSize\": null,\n      \"dealAvailsId\": \"ZHRiOmFwc2M3Y2E0NmZj\",\n      \"deviceType\": null,\n      \"domainEntry\": null,\n      \"eligibleAvails\": \"example-eligible-avails\",\n      \"eligibleAvailsTargeting\": null,\n      \"groupByAttributes\": null,\n      \"inventoryType\": null,\n      \"supplierSellerId\": null,\n      \"totalAvails\": \"example-total-avails\"\n    }\n  ],\n  \"nextToken\": null\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "DealPerformances",
+          "item": [
+            {
+              "name": "Retrieve performance metrics for each specified deal",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/dealPerformances/dsp?advertisingDealId=&performanceEndDate=&performanceStartDate=&nextToken=&maxResults=",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "dealPerformances",
+                    "dsp"
+                  ],
+                  "query": [
+                    {
+                      "key": "advertisingDealId",
+                      "value": "",
+                      "disabled": false
+                    },
+                    {
+                      "key": "performanceEndDate",
+                      "value": "",
+                      "disabled": true
+                    },
+                    {
+                      "key": "performanceStartDate",
+                      "value": "",
+                      "disabled": true
+                    },
+                    {
+                      "key": "nextToken",
+                      "value": "",
+                      "disabled": true
+                    },
+                    {
+                      "key": "maxResults",
+                      "value": "",
+                      "disabled": true
+                    }
+                  ]
+                },
+                "description": "Retrieve performance metrics for each specified deal"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/dealPerformances/dsp?advertisingDealId=&performanceEndDate=&performanceStartDate=&nextToken=&maxResults=",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "dealPerformances",
+                        "dsp"
+                      ],
+                      "query": [
+                        {
+                          "key": "advertisingDealId",
+                          "value": "",
+                          "disabled": false
+                        },
+                        {
+                          "key": "performanceEndDate",
+                          "value": "",
+                          "disabled": true
+                        },
+                        {
+                          "key": "performanceStartDate",
+                          "value": "",
+                          "disabled": true
+                        },
+                        {
+                          "key": "nextToken",
+                          "value": "",
+                          "disabled": true
+                        },
+                        {
+                          "key": "maxResults",
+                          "value": "",
+                          "disabled": true
+                        }
+                      ]
+                    },
+                    "description": "Retrieve performance metrics for each specified deal"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"dealPerformances\": [\n    {\n      \"advertisingDealId\": \"example-advertising-deal-id\",\n      \"availsByDeviceType\": null,\n      \"availsTotal\": null,\n      \"averageCpm\": 38.98,\n      \"bidRequests\": 629213420,\n      \"bidResponses\": 13306,\n      \"clickthroughCount\": 1,\n      \"completionCount\": 0,\n      \"conversionCount\": 0,\n      \"dealPerformanceId\": \"example-deal-performance-id\",\n      \"measurableImpressions\": 1,\n      \"metricsLastUpdated\": \"2025-01-01T00:00:00Z\",\n      \"performanceEndDate\": \"2026-06-25T00:00:00Z\",\n      \"performanceStartDate\": \"2026-05-26T00:00:00Z\",\n      \"recognizedBids\": null,\n      \"totalImpressions\": 12332,\n      \"totalSpend\": 480.75,\n      \"viewableImpressions\": 1\n    }\n  ],\n  \"nextToken\": null\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "DealPlanningMetricses",
+          "item": [
+            {
+              "name": "List deal planning metrics for specified deals",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/dealPlanningMetricses/dsp?advertisingDealId=&currencyCode=&nextToken=&maxResults=",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "dealPlanningMetricses",
+                    "dsp"
+                  ],
+                  "query": [
+                    {
+                      "key": "advertisingDealId",
+                      "value": "",
+                      "disabled": false
+                    },
+                    {
+                      "key": "currencyCode",
+                      "value": "",
+                      "disabled": true,
+                      "description": "\n**CurrencyCode Enum:**\n| CurrencyCode | Description |\n| --- | --- |\n| `AED` | United Arab Emirates Dirham |\n| `AUD` | Australian Dollar |\n| `BRL` | Brazilian Real |\n| `CAD` | Canadian Dollar |\n| `CNY` | Chinese Yuan |\n| `EUR` | Euro |\n| `GBP` | British Pound Sterling |\n| `INR` | Indian Rupee |\n| `JPY` | Japanese Yen |\n| `MXN` | Mexican Peso |\n| `SAR` | Saudi Riyal |\n| `SEK` | Swedish Krona |\n| `SGD` | Singapore Dollar |\n| `TRY` | Turkish Lira |\n| `USD` | United States Dollar |\n"
+                    },
+                    {
+                      "key": "nextToken",
+                      "value": "",
+                      "disabled": true
+                    },
+                    {
+                      "key": "maxResults",
+                      "value": "",
+                      "disabled": true
+                    }
+                  ]
+                },
+                "description": "List deal planning metrics for specified deals"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/dealPlanningMetricses/dsp?advertisingDealId=&currencyCode=&nextToken=&maxResults=",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "dealPlanningMetricses",
+                        "dsp"
+                      ],
+                      "query": [
+                        {
+                          "key": "advertisingDealId",
+                          "value": "",
+                          "disabled": false
+                        },
+                        {
+                          "key": "currencyCode",
+                          "value": "",
+                          "disabled": true,
+                          "description": "\n**CurrencyCode Enum:**\n| CurrencyCode | Description |\n| --- | --- |\n| `AED` | United Arab Emirates Dirham |\n| `AUD` | Australian Dollar |\n| `BRL` | Brazilian Real |\n| `CAD` | Canadian Dollar |\n| `CNY` | Chinese Yuan |\n| `EUR` | Euro |\n| `GBP` | British Pound Sterling |\n| `INR` | Indian Rupee |\n| `JPY` | Japanese Yen |\n| `MXN` | Mexican Peso |\n| `SAR` | Saudi Riyal |\n| `SEK` | Swedish Krona |\n| `SGD` | Singapore Dollar |\n| `TRY` | Turkish Lira |\n| `USD` | United States Dollar |\n"
+                        },
+                        {
+                          "key": "nextToken",
+                          "value": "",
+                          "disabled": true
+                        },
+                        {
+                          "key": "maxResults",
+                          "value": "",
+                          "disabled": true
+                        }
+                      ]
+                    },
+                    "description": "List deal planning metrics for specified deals"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"dealPlanningMetricses\": [\n    {\n      \"advertisingDealId\": \"example-advertising-deal-id\",\n      \"clickThroughRate\": 0.0007708568167661466,\n      \"currency\": \"USD\",\n      \"dealPlanningMetricsId\": \"example-deal-planning-metrics-id\",\n      \"effectiveCPM\": 3.728754464488866,\n      \"measuredRate\": 0.9227261295911444,\n      \"videoCompletionRate\": 0.10714285714285714,\n      \"viewRate\": 0.771177342273181,\n      \"viewableCPM\": 5.240065384898819\n    }\n  ],\n  \"nextToken\": null\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Events",
+          "item": [
+            {
+              "name": "Create Event Data",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/events",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "events"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"events\": [\n    {\n      \"countryCode\": \"AD\",\n      \"eventDescription\": {},\n      \"eventTime\": \"2025-01-01T00:00:00Z\",\n      \"matchKeys\": []\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create Event Data"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/events",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "events"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"events\": [\n    {\n      \"countryCode\": \"AD\",\n      \"eventDescription\": {},\n      \"eventTime\": \"2025-01-01T00:00:00Z\",\n      \"matchKeys\": []\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create Event Data"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"success\": [\n    {\n      \"event\": {\n        \"amazonAdEventKey\": null,\n        \"consent\": null,\n        \"countryCode\": \"US\",\n        \"currencyCode\": null,\n        \"customData\": null,\n        \"dataProcessingOptions\": null,\n        \"eventDescription\": {\n          \"conversionType\": \"OTHER\",\n          \"dataSetName\": null,\n          \"eventIngestionMethod\": \"SERVER_TO_SERVER\",\n          \"eventSource\": \"OFFLINE\",\n          \"name\": \"Sample name\"\n        },\n        \"eventId\": \"EXAMPLEULID00000000000000\",\n        \"eventTime\": \"2025-01-01T00:00:00Z\",\n        \"matchKeys\": [\n          {\n            \"type\": \"MATCH_ID\",\n            \"values\": [\n              \"00000000000000000000000000000000\"\n            ]\n          }\n        ],\n        \"partner\": null,\n        \"unitsSold\": null,\n        \"value\": null\n      },\n      \"index\": 0\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "InventoryGroups",
+          "item": [
+            {
+              "name": "Create inventory groups",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/inventoryGroups/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "inventoryGroups",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"inventoryType\": \"STREAMING_TV\",\n  \"inventoryGroupName\": \"Sample inventoryGroupName\",\n  \"dealIds\": [\n    \"example-deal-ids\",\n    \"example-deal-ids\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create inventory groups"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/inventoryGroups/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "inventoryGroups",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"inventoryType\": \"STREAMING_TV\",\n  \"inventoryGroupName\": \"Sample inventoryGroupName\",\n  \"dealIds\": [\n    \"example-deal-ids\",\n    \"example-deal-ids\"\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create inventory groups"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"success\": []\n}"
+                }
+              ]
+            },
+            {
+              "name": "Query inventory groups with filters",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/inventoryGroups/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "inventoryGroups",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"maxResults\": 1\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query inventory groups with filters"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/inventoryGroups/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "inventoryGroups",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"maxResults\": 1\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query inventory groups with filters"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"inventoryGroups\": [\n    {\n      \"adProduct\": \"AMAZON_DSP\",\n      \"advertisingDealIds\": [\n        \"example-advertising-deal-ids\",\n        \"example-advertising-deal-ids\",\n        \"example-advertising-deal-ids\",\n        \"example-advertising-deal-ids\"\n      ],\n      \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n      \"curationSourceSettings\": null,\n      \"curationSourceType\": \"ADVERTISER_CURATED\",\n      \"description\": null,\n      \"inventoryGroupId\": \"example-inventory-group-id\",\n      \"inventoryType\": null,\n      \"lastUpdatedDateTime\": null,\n      \"name\": \"Sample name\"\n    }\n  ],\n  \"nextToken\": \"ZWI1NzgwNzExMjA3ZmY0MzgxYjJmZWMwY2NkOGEyY2MtM2VlMDhhOGM3MDEyMGNkZWExZGZmOTIxZjY5NTkyOGEtMg==\",\n  \"totalResults\": 1\n}"
+                }
+              ]
+            },
+            {
+              "name": "Retrieve inventory groups by ID",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/retrieve/inventoryGroups/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "retrieve",
+                    "inventoryGroups",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"inventoryGroupIds\": [\n    \"example-inventory-group-ids\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Retrieve inventory groups by ID"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/retrieve/inventoryGroups/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "retrieve",
+                        "inventoryGroups",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"inventoryGroupIds\": [\n    \"example-inventory-group-ids\"\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Retrieve inventory groups by ID"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"success\": [\n    {\n      \"index\": 0,\n      \"inventoryGroup\": {\n        \"adProduct\": \"AMAZON_DSP\",\n        \"advertisingDealIds\": [],\n        \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n        \"curationSourceSettings\": {\n          \"automaticDealSelectionControls\": {\n            \"dealTypePreference\": \"ALL\",\n            \"supplyAllowlist\": {\n              \"openInternet\": {\n                \"enabled\": true\n              }\n            }\n          }\n        },\n        \"curationSourceType\": \"AMAZON_CURATED_AGENT\",\n        \"description\": \"Sample description\",\n        \"inventoryGroupId\": \"example-inventory-group-id\",\n        \"inventoryType\": \"DISPLAY\",\n        \"lastUpdatedDateTime\": null,\n        \"name\": \"Sample name\"\n      }\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Update inventory groups",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/update/inventoryGroups/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "update",
+                    "inventoryGroups",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"inventoryGroups\": [\n    {\n      \"inventoryGroupId\": \"example-inventory-group-id\",\n      \"curationSourceSettings\": {\n        \"automaticDealSelectionControls\": {\n          \"dealTypePreference\": \"ALL\",\n          \"supplyAllowlist\": {\n            \"openInternet\": {\n              \"enabled\": true\n            }\n          }\n        }\n      }\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update inventory groups"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/update/inventoryGroups/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "update",
+                        "inventoryGroups",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"inventoryGroups\": [\n    {\n      \"inventoryGroupId\": \"example-inventory-group-id\",\n      \"curationSourceSettings\": {\n        \"automaticDealSelectionControls\": {\n          \"dealTypePreference\": \"ALL\",\n          \"supplyAllowlist\": {\n            \"openInternet\": {\n              \"enabled\": true\n            }\n          }\n        }\n      }\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Update inventory groups"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"success\": [\n    {\n      \"index\": 0,\n      \"inventoryGroup\": {\n        \"adProduct\": \"AMAZON_DSP\",\n        \"advertisingDealIds\": [],\n        \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n        \"curationSourceSettings\": {\n          \"automaticDealSelectionControls\": {\n            \"dealTypePreference\": \"ALL\",\n            \"supplyAllowlist\": {\n              \"openInternet\": {\n                \"enabled\": true\n              }\n            }\n          }\n        },\n        \"curationSourceType\": \"AMAZON_CURATED_AGENT\",\n        \"description\": \"Sample description\",\n        \"inventoryGroupId\": \"example-inventory-group-id\",\n        \"inventoryType\": \"DISPLAY\",\n        \"lastUpdatedDateTime\": null,\n        \"name\": \"Sample name\"\n      }\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Labels",
+          "item": [
+            {
+              "name": "D S P Ads Apiv1 Query Label",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/labels/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "labels",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"labelObjectTypeFilter\": {\n    \"include\": [\n      \"AD_GROUP\"\n    ]\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "D S P Ads Apiv1 Query Label"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/labels/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "labels",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"labelObjectTypeFilter\": {\n    \"include\": [\n      \"AD_GROUP\"\n    ]\n  }\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "D S P Ads Apiv1 Query Label"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"labels\": [\n    {\n      \"labelId\": \"sample-labelId\",\n      \"labelName\": \"sample-labelName\"\n    }\n  ],\n  \"nextToken\": \"sample-nextToken\"\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "LinearTvDayparts",
+          "item": [
+            {
+              "name": "List all supported Linear TV Daypart",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/linearTvDayparts",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "linearTvDayparts"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"marketplaceFilter\": {\n    \"include\": [\n      \"US\"\n    ]\n  },\n  \"maxResults\": 20\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "List all supported Linear TV Daypart"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/linearTvDayparts",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "linearTvDayparts"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"marketplaceFilter\": {\n    \"include\": [\n      \"US\"\n    ]\n  },\n  \"maxResults\": 20\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "List all supported Linear TV Daypart"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"_truncated\": true\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "LinearTvIncrementalReachForecasts",
+          "item": [
+            {
+              "name": "Create Linear Tv Incremental Reach Forecast",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/linearTvIncrementalReachForecasts",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "linearTvIncrementalReachForecasts"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"linearTvIncrementalReachForecasts\": [\n    {\n      \"marketplace\": \"US\",\n      \"startDate\": \"2026-06-22\",\n      \"endDate\": \"2026-12-22\",\n      \"reachUnit\": \"HOUSEHOLD\",\n      \"linearTvInventoryAllocation\": [\n        {\n          \"inventoryType\": \"BROADCAST\",\n          \"linearTvDaypartId\": \"EARLY_FRINGE\",\n          \"grossRatingPoint\": 2000.0\n        },\n        {\n          \"inventoryType\": \"BROADCAST\",\n          \"linearTvDaypartId\": \"LATE_FRINGE\",\n          \"grossRatingPoint\": 3000.0\n        }\n      ],\n      \"streamingTvBudgetAllocation\": [\n        {\n          \"reachForecastId\": \"example-reach-forecast-id\",\n          \"budget\": {\n            \"recurrenceTimePeriod\": null,\n            \"budgetType\": \"IMPRESSION\",\n            \"budgetValue\": {\n              \"impressionBudgetValue\": {\n                \"impression\": 3000.0\n              }\n            }\n          }\n        },\n        {\n          \"reachForecastId\": \"example-reach-forecast-id\",\n          \"budget\": {\n            \"recurrenceTimePeriod\": null,\n            \"budgetType\": \"IMPRESSION\",\n            \"budgetValue\": {\n              \"impressionBudgetValue\": {\n                \"impression\": 3000.0\n              }\n            }\n          }\n        }\n      ]\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create Linear Tv Incremental Reach Forecast"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/linearTvIncrementalReachForecasts",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "linearTvIncrementalReachForecasts"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"linearTvIncrementalReachForecasts\": [\n    {\n      \"marketplace\": \"US\",\n      \"startDate\": \"2026-06-22\",\n      \"endDate\": \"2026-12-22\",\n      \"reachUnit\": \"HOUSEHOLD\",\n      \"linearTvInventoryAllocation\": [\n        {\n          \"inventoryType\": \"BROADCAST\",\n          \"linearTvDaypartId\": \"EARLY_FRINGE\",\n          \"grossRatingPoint\": 2000.0\n        },\n        {\n          \"inventoryType\": \"BROADCAST\",\n          \"linearTvDaypartId\": \"LATE_FRINGE\",\n          \"grossRatingPoint\": 3000.0\n        }\n      ],\n      \"streamingTvBudgetAllocation\": [\n        {\n          \"reachForecastId\": \"example-reach-forecast-id\",\n          \"budget\": {\n            \"recurrenceTimePeriod\": null,\n            \"budgetType\": \"IMPRESSION\",\n            \"budgetValue\": {\n              \"impressionBudgetValue\": {\n                \"impression\": 3000.0\n              }\n            }\n          }\n        },\n        {\n          \"reachForecastId\": \"example-reach-forecast-id\",\n          \"budget\": {\n            \"recurrenceTimePeriod\": null,\n            \"budgetType\": \"IMPRESSION\",\n            \"budgetValue\": {\n              \"impressionBudgetValue\": {\n                \"impression\": 3000.0\n              }\n            }\n          }\n        }\n      ]\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create Linear Tv Incremental Reach Forecast"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"success\": [\n    {\n      \"index\": 0,\n      \"linearTvIncrementalReachForecast\": {\n        \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n        \"deduplicatedReachPercent\": 67.98086524581022,\n        \"endDate\": \"2026-12-22\",\n        \"linearTvIncrementalReachForecastId\": \"example-linear-tv-incremental-reach-forecast-id\",\n        \"linearTvInventoryAllocation\": [\n          {\n            \"grossRatingPoint\": 2000.0,\n            \"inventoryType\": \"BROADCAST\",\n            \"linearTvDaypartId\": \"EARLY_FRINGE\"\n          },\n          {\n            \"grossRatingPoint\": 3000.0,\n            \"inventoryType\": \"BROADCAST\",\n            \"linearTvDaypartId\": \"LATE_FRINGE\"\n          }\n        ],\n        \"linearTvOnlyReachPercent\": 67.97834588355452,\n        \"marketplace\": \"US\",\n        \"overlapReachPercent\": 0.0016541164454812456,\n        \"reachUnit\": \"HOUSEHOLD\",\n        \"startDate\": \"2026-06-22\",\n        \"streamingTvBudgetAllocation\": [\n          {\n            \"budget\": {\n              \"budgetType\": \"IMPRESSION\",\n              \"budgetValue\": {\n                \"impressionBudgetValue\": {\n                  \"impression\": 3000.0\n                }\n              }\n            },\n            \"reachForecastId\": \"example-reach-forecast-id\"\n          },\n          {\n            \"budget\": {\n              \"budgetType\": \"IMPRESSION\",\n              \"budgetValue\": {\n                \"impressionBudgetValue\": {\n                  \"impression\": 3000.0\n                }\n              }\n            },\n            \"reachForecastId\": \"example-reach-forecast-id\"\n          }\n        ],\n        \"streamingTvExclusiveReachRate\": 34.3438427031677,\n        \"streamingTvIncrementalReachRate\": 0.0012727946605200701,\n        \"streamingTvOnlyReachPercent\": 0.0008652458102215438\n      }\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "LinearTvReachForecasts",
+          "item": [
+            {
+              "name": "Generate Linear TV reach forecast",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/linearTvReachForecasts",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "linearTvReachForecasts"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"linearTvReachForecasts\": [\n    {\n      \"marketplace\": \"US\",\n      \"startDate\": \"2026-06-22\",\n      \"endDate\": \"2026-12-22\",\n      \"reachUnit\": \"HOUSEHOLD\",\n      \"linearTvInventoryAllocation\": [\n        {\n          \"inventoryType\": \"BROADCAST\",\n          \"linearTvDaypartId\": \"EARLY_FRINGE\",\n          \"grossRatingPoint\": 2000.0\n        },\n        {\n          \"inventoryType\": \"BROADCAST\",\n          \"linearTvDaypartId\": \"LATE_FRINGE\",\n          \"grossRatingPoint\": 3000.0\n        }\n      ]\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Generate Linear TV reach forecast"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/linearTvReachForecasts",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "linearTvReachForecasts"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"linearTvReachForecasts\": [\n    {\n      \"marketplace\": \"US\",\n      \"startDate\": \"2026-06-22\",\n      \"endDate\": \"2026-12-22\",\n      \"reachUnit\": \"HOUSEHOLD\",\n      \"linearTvInventoryAllocation\": [\n        {\n          \"inventoryType\": \"BROADCAST\",\n          \"linearTvDaypartId\": \"EARLY_FRINGE\",\n          \"grossRatingPoint\": 2000.0\n        },\n        {\n          \"inventoryType\": \"BROADCAST\",\n          \"linearTvDaypartId\": \"LATE_FRINGE\",\n          \"grossRatingPoint\": 3000.0\n        }\n      ]\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Generate Linear TV reach forecast"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"success\": [\n    {\n      \"index\": 0,\n      \"linearTvReachForecast\": {\n        \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n        \"endDate\": \"2026-12-22\",\n        \"linearTvInventoryAllocation\": [\n          {\n            \"grossRatingPoint\": 2000.0,\n            \"inventoryType\": \"BROADCAST\",\n            \"linearTvDaypartId\": \"EARLY_FRINGE\"\n          },\n          {\n            \"grossRatingPoint\": 3000.0,\n            \"inventoryType\": \"BROADCAST\",\n            \"linearTvDaypartId\": \"LATE_FRINGE\"\n          }\n        ],\n        \"linearTvReachForecastId\": \"example-linear-tv-reach-forecast-id\",\n        \"linearTvReachPercent\": 67.98,\n        \"marketplace\": \"US\",\n        \"reachUnit\": \"HOUSEHOLD\",\n        \"startDate\": \"2026-06-22\"\n      }\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "ManagerAccounts",
+          "item": [
+            {
+              "name": "Create manager accounts",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/managerAccounts",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "managerAccounts"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"managerAccounts\": [\n    {}\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create manager accounts"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/managerAccounts",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "managerAccounts"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"managerAccounts\": [\n    {}\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create manager accounts"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [],\n      \"index\": 0\n    }\n  ],\n  \"success\": [\n    {\n      \"index\": 0,\n      \"managerAccount\": {}\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "List manager accounts",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/managerAccounts",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "managerAccounts"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"managerAccountIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  },\n  \"maxResults\": 10,\n  \"nextToken\": \"sample-nextToken\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "List manager accounts"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/managerAccounts",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "managerAccounts"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"managerAccountIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  },\n  \"maxResults\": 10,\n  \"nextToken\": \"sample-nextToken\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "List manager accounts"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"managerAccounts\": [\n    {}\n  ],\n  \"nextToken\": \"sample-nextToken\"\n}"
+                }
+              ]
+            },
+            {
+              "name": "Update manager accounts",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/update/managerAccounts",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "update",
+                    "managerAccounts"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"managerAccounts\": [\n    {\n      \"managerAccountId\": \"example-manager-account-id\",\n      \"displayName\": \"Sample displayName\",\n      \"businessDetails\": {\n        \"address\": {\n          \"businessName\": \"Sample businessName\",\n          \"addressLine1\": \"4 Ellen Drive\",\n          \"phoneNumber\": \"example-phone-number\",\n          \"city\": \"Farmington\",\n          \"state\": \"CT\",\n          \"zipCode\": \"06032\",\n          \"countryCode\": \"US\"\n        }\n      }\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update manager accounts"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/update/managerAccounts",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "update",
+                        "managerAccounts"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"managerAccounts\": [\n    {\n      \"managerAccountId\": \"example-manager-account-id\",\n      \"displayName\": \"Sample displayName\",\n      \"businessDetails\": {\n        \"address\": {\n          \"businessName\": \"Sample businessName\",\n          \"addressLine1\": \"4 Ellen Drive\",\n          \"phoneNumber\": \"example-phone-number\",\n          \"city\": \"Farmington\",\n          \"state\": \"CT\",\n          \"zipCode\": \"06032\",\n          \"countryCode\": \"US\"\n        }\n      }\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Update manager accounts"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [],\n  \"success\": [\n    {\n      \"index\": 0,\n      \"managerAccount\": {\n        \"businessDetails\": {\n          \"address\": {\n            \"addressLine1\": \"4 Ellen Drive\",\n            \"businessName\": \"Sample businessName\",\n            \"city\": \"Farmington\",\n            \"countryCode\": \"US\",\n            \"phoneNumber\": \"example-phone-number\",\n            \"state\": \"CT\",\n            \"zipCode\": \"06032\"\n          }\n        },\n        \"displayName\": \"Sample displayName\",\n        \"managerAccountId\": \"example-manager-account-id\"\n      }\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Publishers",
+          "item": [
+            {
+              "name": "List all Publishers",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Advertising-API-Scope",
+                    "value": "{{profileId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/publishers",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "publishers"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"maxResults\": 1000\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "List all Publishers"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Advertising-API-Scope",
+                        "value": "{{profileId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/publishers",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "publishers"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"maxResults\": 1000\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "List all Publishers"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"_truncated\": true\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Reports",
+          "item": [
+            {
+              "name": "Create a report",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/reports",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "reports"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"reports\": [\n    {\n      \"format\": \"CSV\",\n      \"periods\": [\n        {\n          \"datePeriod\": {\n            \"startDate\": \"2026-05-16\",\n            \"endDate\": \"2026-05-17\"\n          }\n        }\n      ],\n      \"query\": {\n        \"fields\": [\n          \"budgetCurrency.value\",\n          \"dateRange.value\",\n          \"advertiserAccount.id\",\n          \"advertiserAccount.name\",\n          \"campaign.id\",\n          \"campaign.name\",\n          \"metric.impressions\",\n          \"metric.clicks\",\n          \"metric.ctr\",\n          \"metric.supplyCost\",\n          \"metric.totalCost\",\n          \"metric.purchases\",\n          \"metric.sales\",\n          \"metric.unitsSold\",\n          \"metric.costPerPurchase\",\n          \"metric.purchaseRate\",\n          \"metric.roas\",\n          \"metric.purchasesPromoted\",\n          \"metric.salesPromoted\",\n          \"metric.unitsSoldPromoted\",\n          \"metric.costPerPurchasePromoted\",\n          \"metric.purchaseRatePromoted\",\n          \"metric.roasPromoted\",\n          \"metric.newToBrandPurchases\",\n          \"metric.newToBrandRoas\",\n          \"metric.newToBrandSales\",\n          \"metric.newToBrandUnitsSold\",\n          \"metric.costPerNewToBrandPurchase\",\n          \"metric.newToBrandPurchaseRate\",\n          \"metric.detailPageViews\",\n          \"metric.costPerDetailPageView\",\n          \"metric.detailPageViewRate\"\n        ]\n      }\n    }\n  ],\n  \"accessRequestedAccounts\": [\n    {\n      \"advertiserAccountId\": \"example-advertiser-account-id\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create a report"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/reports",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "reports"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"reports\": [\n    {\n      \"format\": \"CSV\",\n      \"periods\": [\n        {\n          \"datePeriod\": {\n            \"startDate\": \"2026-05-16\",\n            \"endDate\": \"2026-05-17\"\n          }\n        }\n      ],\n      \"query\": {\n        \"fields\": [\n          \"budgetCurrency.value\",\n          \"dateRange.value\",\n          \"advertiserAccount.id\",\n          \"advertiserAccount.name\",\n          \"campaign.id\",\n          \"campaign.name\",\n          \"metric.impressions\",\n          \"metric.clicks\",\n          \"metric.ctr\",\n          \"metric.supplyCost\",\n          \"metric.totalCost\",\n          \"metric.purchases\",\n          \"metric.sales\",\n          \"metric.unitsSold\",\n          \"metric.costPerPurchase\",\n          \"metric.purchaseRate\",\n          \"metric.roas\",\n          \"metric.purchasesPromoted\",\n          \"metric.salesPromoted\",\n          \"metric.unitsSoldPromoted\",\n          \"metric.costPerPurchasePromoted\",\n          \"metric.purchaseRatePromoted\",\n          \"metric.roasPromoted\",\n          \"metric.newToBrandPurchases\",\n          \"metric.newToBrandRoas\",\n          \"metric.newToBrandSales\",\n          \"metric.newToBrandUnitsSold\",\n          \"metric.costPerNewToBrandPurchase\",\n          \"metric.newToBrandPurchaseRate\",\n          \"metric.detailPageViews\",\n          \"metric.costPerDetailPageView\",\n          \"metric.detailPageViewRate\"\n        ]\n      }\n    }\n  ],\n  \"accessRequestedAccounts\": [\n    {\n      \"advertiserAccountId\": \"example-advertiser-account-id\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create a report"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": null,\n  \"success\": [\n    {\n      \"index\": 0,\n      \"report\": {\n        \"completedDateTime\": null,\n        \"completedReportParts\": null,\n        \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n        \"currencyOfView\": null,\n        \"failureCode\": null,\n        \"failureReason\": null,\n        \"format\": \"CSV\",\n        \"formatOptions\": null,\n        \"lastUpdatedDateTime\": \"2025-01-01T00:00:00Z\",\n        \"linkedAccounts\": [\n          {\n            \"advertiserAccountId\": \"example-advertiser-account-id\"\n          }\n        ],\n        \"locale\": null,\n        \"periods\": [\n          {\n            \"datePeriod\": {\n              \"endDate\": \"2026-05-17\",\n              \"startDate\": \"2026-05-16\"\n            }\n          }\n        ],\n        \"query\": {\n          \"fields\": [\n            \"budgetCurrency.value\",\n            \"dateRange.value\",\n            \"advertiserAccount.id\",\n            \"advertiserAccount.name\",\n            \"campaign.id\",\n            \"campaign.name\",\n            \"metric.impressions\",\n            \"metric.clicks\",\n            \"metric.ctr\",\n            \"metric.supplyCost\",\n            \"metric.totalCost\",\n            \"metric.purchases\",\n            \"metric.sales\",\n            \"metric.unitsSold\",\n            \"metric.costPerPurchase\",\n            \"metric.purchaseRate\",\n            \"metric.roas\",\n            \"metric.purchasesPromoted\",\n            \"metric.salesPromoted\",\n            \"metric.unitsSoldPromoted\",\n            \"metric.costPerPurchasePromoted\",\n            \"metric.purchaseRatePromoted\",\n            \"metric.roasPromoted\",\n            \"metric.newToBrandPurchases\",\n            \"metric.newToBrandRoas\",\n            \"metric.newToBrandSales\",\n            \"metric.newToBrandUnitsSold\",\n            \"metric.costPerNewToBrandPurchase\",\n            \"metric.newToBrandPurchaseRate\",\n            \"metric.detailPageViews\",\n            \"metric.costPerDetailPageView\",\n            \"metric.detailPageViewRate\"\n          ],\n          \"filter\": null\n        },\n        \"reportId\": \"example-report-id\",\n        \"status\": \"PENDING\",\n        \"timeZoneMode\": null\n      }\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Delete a report by ID",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/delete/reports",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "delete",
+                    "reports"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"reportIds\": [\n    \"example-report-ids\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Delete a report by ID"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/delete/reports",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "delete",
+                        "reports"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"reportIds\": [\n    \"example-report-ids\"\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Delete a report by ID"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": null,\n  \"success\": [\n    {\n      \"index\": 0,\n      \"report\": {\n        \"completedDateTime\": null,\n        \"completedReportParts\": null,\n        \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n        \"currencyOfView\": null,\n        \"failureCode\": null,\n        \"failureReason\": null,\n        \"format\": \"GZIP_JSON\",\n        \"formatOptions\": null,\n        \"lastUpdatedDateTime\": \"2025-01-01T00:00:00Z\",\n        \"linkedAccounts\": [\n          {\n            \"advertiserAccountId\": \"example-advertiser-account-id\"\n          }\n        ],\n        \"locale\": null,\n        \"periods\": [\n          {\n            \"datePeriod\": {\n              \"endDate\": \"2026-05-23\",\n              \"startDate\": \"2026-05-17\"\n            }\n          }\n        ],\n        \"query\": {\n          \"fields\": [\n            \"date.value\",\n            \"adProduct.value\",\n            \"campaign.id\",\n            \"campaign.name\",\n            \"metric.impressions\",\n            \"metric.clicks\",\n            \"metric.totalCost\",\n            \"metric.sales\",\n            \"budgetCurrency.value\"\n          ],\n          \"filter\": null\n        },\n        \"reportId\": \"example-report-id\",\n        \"status\": \"DELETED\",\n        \"timeZoneMode\": null\n      }\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Retrieve a report by ID",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/retrieve/reports",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "retrieve",
+                    "reports"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"reportIds\": [\n    \"example-report-ids\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Retrieve a report by ID"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/retrieve/reports",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "retrieve",
+                        "reports"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"reportIds\": [\n    \"example-report-ids\"\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Retrieve a report by ID"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": null,\n  \"success\": [\n    {\n      \"index\": 0,\n      \"report\": {\n        \"completedDateTime\": null,\n        \"completedReportParts\": null,\n        \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n        \"currencyOfView\": null,\n        \"failureCode\": null,\n        \"failureReason\": null,\n        \"format\": \"CSV\",\n        \"formatOptions\": null,\n        \"lastUpdatedDateTime\": \"2025-01-01T00:00:00Z\",\n        \"linkedAccounts\": [\n          {\n            \"advertiserAccountId\": \"example-advertiser-account-id\"\n          }\n        ],\n        \"locale\": null,\n        \"periods\": [\n          {\n            \"datePeriod\": {\n              \"endDate\": \"2026-05-17\",\n              \"startDate\": \"2026-05-04\"\n            }\n          }\n        ],\n        \"query\": {\n          \"fields\": [\n            \"advertiserAccount.id\",\n            \"advertiserAccount.name\",\n            \"advertiserAccount.timeZone\",\n            \"advertiserAccount.entityId\",\n            \"date.value\",\n            \"adGroup.id\",\n            \"adGroup.name\",\n            \"campaign.id\",\n            \"adProduct.value\",\n            \"metric.addToList\",\n            \"metric.impressions\",\n            \"metric.clicks\",\n            \"metric.purchases\",\n            \"metric.purchasesHalo\",\n            \"metric.purchasesPromoted\",\n            \"metric.sales\",\n            \"metric.salesHalo\",\n            \"metric.salesPromoted\",\n            \"metric.totalCost\",\n            \"budgetCurrency.value\",\n            \"metric.viewableImpressions\",\n            \"metric.brandedSearches\",\n            \"metric.detailPageViews\",\n            \"metric.detailPageViewsPromoted\",\n            \"metric.detailPageViewsHalo\",\n            \"metric.newToBrandDetailPageViews\",\n            \"metric.unitsSold\",\n            \"metric.addToCart\",\n            \"metric.unitsSoldPromoted\",\n            \"metric.addToCartPromoted\",\n            \"metric.unitsSoldHalo\",\n            \"metric.addToCartHalo\",\n            \"metric.newToBrandSales\",\n            \"metric.newToBrandPurchases\",\n            \"metric.newToBrandUnitsSold\",\n            \"metric.newToBrandAddToCart\",\n            \"metric.newToBrandSalesPromoted\",\n            \"metric.newToBrandPurchasesPromoted\",\n            \"metric.newToBrandUnitsSoldPromoted\",\n            \"metric.newToBrandAddToCartPromoted\",\n            \"metric.newToBrandSalesHalo\",\n            \"metric.newToBrandPurchasesHalo\",\n            \"metric.newToBrandUnitsSoldHalo\",\n            \"metric.newToBrandAddToCartHalo\",\n            \"metric.completeViewsVideoAd\",\n            \"metric.firstQuartileVideoAd\",\n            \"metric.midpointVideoAd\",\n            \"metric.thirdQuartileVideoAd\",\n            \"metric.completeListensAudioAd\",\n            \"metric.unmutesVideoAd\",\n            \"metric.unmutesAudioAd\",\n            \"metric.kindleEditionNormalizedPagesRead\",\n            \"metric.estimatedKindleUnlimitedRoyalties\"\n          ],\n          \"filter\": null\n        },\n        \"reportId\": \"example-report-id\",\n        \"status\": \"PENDING\",\n        \"timeZoneMode\": null\n      }\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "RuleLinks",
+          "item": [
+            {
+              "name": "Create adjustment rule associations",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/ruleLinks",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "ruleLinks"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"ruleLinks\": [\n    {\n      \"ruleLinkId\": {\n        \"ruleId\": \"example-rule-id\",\n        \"ruleLinkEntityType\": \"AD_GROUP\",\n        \"entityId\": {\n          \"adGroup\": \"example-ad-group\"\n        }\n      },\n      \"state\": \"ENABLED\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create adjustment rule associations"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/ruleLinks",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "ruleLinks"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"ruleLinks\": [\n    {\n      \"ruleLinkId\": {\n        \"ruleId\": \"example-rule-id\",\n        \"ruleLinkEntityType\": \"AD_GROUP\",\n        \"entityId\": {\n          \"adGroup\": \"example-ad-group\"\n        }\n      },\n      \"state\": \"ENABLED\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create adjustment rule associations"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"success\": [\n    {\n      \"index\": 0\n    }\n  ],\n  \"error\": []\n}"
+                }
+              ]
+            },
+            {
+              "name": "Delete adjustment rule associations",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/delete/ruleLinks",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "delete",
+                    "ruleLinks"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"ruleLinkIds\": [\n    {\n      \"ruleId\": \"example-rule-id\",\n      \"ruleLinkEntityType\": \"AD_GROUP\",\n      \"entityId\": {\n        \"adGroup\": \"example-ad-group\"\n      }\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Delete adjustment rule associations"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/delete/ruleLinks",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "delete",
+                        "ruleLinks"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"ruleLinkIds\": [\n    {\n      \"ruleId\": \"example-rule-id\",\n      \"ruleLinkEntityType\": \"AD_GROUP\",\n      \"entityId\": {\n        \"adGroup\": \"example-ad-group\"\n      }\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Delete adjustment rule associations"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"success\": [\n    {\n      \"index\": 0\n    }\n  ],\n  \"error\": []\n}"
+                }
+              ]
+            },
+            {
+              "name": "Query adjustment rule associations",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/ruleLinks",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "ruleLinks"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"ruleLinkIdFilter\": {\n    \"include\": [\n      {\n        \"ruleId\": \"example-rule-id\",\n        \"ruleLinkEntityType\": \"AD_GROUP\",\n        \"entityId\": {\n          \"adGroup\": \"example-ad-group\"\n        }\n      }\n    ]\n  },\n  \"maxResults\": 10\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query adjustment rule associations"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/ruleLinks",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "ruleLinks"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"ruleLinkIdFilter\": {\n    \"include\": [\n      {\n        \"ruleId\": \"example-rule-id\",\n        \"ruleLinkEntityType\": \"AD_GROUP\",\n        \"entityId\": {\n          \"adGroup\": \"example-ad-group\"\n        }\n      }\n    ]\n  },\n  \"maxResults\": 10\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query adjustment rule associations"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"ruleLinks\": [\n    {\n      \"ruleLinkId\": {\n        \"ruleId\": \"example-rule-id\",\n        \"ruleLinkEntityType\": \"AD_GROUP\",\n        \"entityId\": {\n          \"adGroup\": \"example-ad-group\"\n        }\n      },\n      \"state\": \"ENABLED\",\n      \"status\": {\n        \"deliveryStatus\": \"DELIVERING\",\n        \"deliveryReasons\": []\n      }\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Rules",
+          "item": [
+            {
+              "name": "Create adjustment rules",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/rules",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "rules"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"rules\": [\n    {\n      \"ruleId\": \"example-rule-id\",\n      \"name\": \"Sample name\",\n      \"adProduct\": \"AMAZON_DSP\",\n      \"state\": \"ENABLED\",\n      \"expressionType\": \"DIMENSION_RULE_EXPRESSION\",\n      \"expression\": [\n        {\n          \"dimensionRuleExpression\": {\n            \"conditions\": {\n              \"criteriaCondition\": {\n                \"criteriaJoinOperator\": \"AND\",\n                \"criteria\": [\n                  {\n                    \"dimensionCriteria\": {\n                      \"dimensionJoinOperator\": \"AND\",\n                      \"dimensions\": [\n                        {\n                          \"dimensionType\": \"DOMAIN\",\n                          \"dimensionValues\": [\n                            \"example.com\"\n                          ]\n                        }\n                      ]\n                    }\n                  }\n                ]\n              }\n            },\n            \"actions\": {\n              \"tierAdjustment\": {\n                \"adjustmentType\": \"INCREASE\"\n              }\n            }\n          }\n        }\n      ],\n      \"tags\": [\n        {\n          \"key\": \"adjustmentType\",\n          \"value\": \"PRIORITY\"\n        }\n      ]\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create adjustment rules"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/rules",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "rules"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"rules\": [\n    {\n      \"ruleId\": \"example-rule-id\",\n      \"name\": \"Sample name\",\n      \"adProduct\": \"AMAZON_DSP\",\n      \"state\": \"ENABLED\",\n      \"expressionType\": \"DIMENSION_RULE_EXPRESSION\",\n      \"expression\": [\n        {\n          \"dimensionRuleExpression\": {\n            \"conditions\": {\n              \"criteriaCondition\": {\n                \"criteriaJoinOperator\": \"AND\",\n                \"criteria\": [\n                  {\n                    \"dimensionCriteria\": {\n                      \"dimensionJoinOperator\": \"AND\",\n                      \"dimensions\": [\n                        {\n                          \"dimensionType\": \"DOMAIN\",\n                          \"dimensionValues\": [\n                            \"example.com\"\n                          ]\n                        }\n                      ]\n                    }\n                  }\n                ]\n              }\n            },\n            \"actions\": {\n              \"tierAdjustment\": {\n                \"adjustmentType\": \"INCREASE\"\n              }\n            }\n          }\n        }\n      ],\n      \"tags\": [\n        {\n          \"key\": \"adjustmentType\",\n          \"value\": \"PRIORITY\"\n        }\n      ]\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create adjustment rules"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"success\": [\n    {\n      \"index\": 0,\n      \"rule\": {\n        \"ruleId\": \"example-rule-id\",\n        \"name\": \"Sample name\",\n        \"adProduct\": \"AMAZON_DSP\",\n        \"state\": \"ENABLED\",\n        \"status\": {\n          \"deliveryStatus\": \"DELIVERING\",\n          \"deliveryReasons\": []\n        },\n        \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n        \"lastUpdatedDateTime\": \"2025-01-01T00:00:00Z\",\n        \"expressionType\": \"DIMENSION_RULE_EXPRESSION\",\n        \"expression\": [\n          {\n            \"dimensionRuleExpression\": {\n              \"conditions\": {\n                \"criteriaCondition\": {\n                  \"criteriaJoinOperator\": \"AND\",\n                  \"criteria\": [\n                    {\n                      \"dimensionCriteria\": {\n                        \"dimensionJoinOperator\": \"AND\",\n                        \"dimensions\": [\n                          {\n                            \"dimensionType\": \"DOMAIN\",\n                            \"dimensionValues\": [\n                              \"example.com\"\n                            ],\n                            \"negative\": false\n                          }\n                        ]\n                      }\n                    }\n                  ]\n                }\n              },\n              \"actions\": {\n                \"tierAdjustment\": {\n                  \"adjustmentType\": \"INCREASE\"\n                }\n              }\n            }\n          }\n        ]\n      }\n    }\n  ],\n  \"error\": []\n}"
+                }
+              ]
+            },
+            {
+              "name": "Delete adjustment rules",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/delete/rules",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "delete",
+                    "rules"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"ruleIds\": [\n    \"example-rule-ids\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Delete adjustment rules"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/delete/rules",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "delete",
+                        "rules"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"ruleIds\": [\n    \"example-rule-ids\"\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Delete adjustment rules"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"success\": [\n    {\n      \"index\": 0\n    }\n  ],\n  \"error\": []\n}"
+                }
+              ]
+            },
+            {
+              "name": "Query adjustment rules",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/rules",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "rules"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"adProductFilter\": {\n    \"include\": [\n      \"AMAZON_DSP\"\n    ]\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query adjustment rules"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/rules",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "rules"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"adProductFilter\": {\n    \"include\": [\n      \"AMAZON_DSP\"\n    ]\n  }\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query adjustment rules"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"nextToken\": \"sample-nextToken\",\n  \"rules\": [\n    {\n      \"adProduct\": \"AMAZON_DSP\",\n      \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n      \"expression\": [],\n      \"expressionType\": \"DIMENSION_RULE_EXPRESSION\",\n      \"lastUpdatedDateTime\": \"2025-01-01T00:00:00Z\",\n      \"name\": \"sample-name\",\n      \"ruleId\": \"sample-ruleId\",\n      \"state\": \"ENABLED\",\n      \"status\": {}\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Retrieve adjustment rules",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/retrieve/rules",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "retrieve",
+                    "rules"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"ruleIds\": [\n    \"example-rule-ids\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Retrieve adjustment rules"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/retrieve/rules",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "retrieve",
+                        "rules"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"ruleIds\": [\n    \"example-rule-ids\"\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Retrieve adjustment rules"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"success\": [],\n  \"error\": [\n    {\n      \"index\": 0,\n      \"errors\": [\n        {\n          \"message\": \"example-message\"\n        }\n      ]\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Update adjustment rules",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/update/rules",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "update",
+                    "rules"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"rules\": [\n    {\n      \"ruleId\": \"example-rule-id\",\n      \"name\": \"Sample name\",\n      \"expression\": [\n        {\n          \"dimensionRuleExpression\": {\n            \"conditions\": {\n              \"criteriaCondition\": {\n                \"criteriaJoinOperator\": \"AND\",\n                \"criteria\": [\n                  {\n                    \"dimensionCriteria\": {\n                      \"dimensionJoinOperator\": \"AND\",\n                      \"dimensions\": [\n                        {\n                          \"dimensionType\": \"AD_FORMAT\",\n                          \"dimensionValues\": [\n                            \"DISPLAY\",\n                            \"VIDEO\"\n                          ]\n                        }\n                      ]\n                    }\n                  }\n                ]\n              }\n            },\n            \"actions\": {\n              \"valueAdjustment\": {\n                \"adjustmentType\": \"MULTIPLIER\",\n                \"adjustmentValue\": 1.5\n              }\n            }\n          }\n        }\n      ]\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update adjustment rules"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/update/rules",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "update",
+                        "rules"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"rules\": [\n    {\n      \"ruleId\": \"example-rule-id\",\n      \"name\": \"Sample name\",\n      \"expression\": [\n        {\n          \"dimensionRuleExpression\": {\n            \"conditions\": {\n              \"criteriaCondition\": {\n                \"criteriaJoinOperator\": \"AND\",\n                \"criteria\": [\n                  {\n                    \"dimensionCriteria\": {\n                      \"dimensionJoinOperator\": \"AND\",\n                      \"dimensions\": [\n                        {\n                          \"dimensionType\": \"AD_FORMAT\",\n                          \"dimensionValues\": [\n                            \"DISPLAY\",\n                            \"VIDEO\"\n                          ]\n                        }\n                      ]\n                    }\n                  }\n                ]\n              }\n            },\n            \"actions\": {\n              \"valueAdjustment\": {\n                \"adjustmentType\": \"MULTIPLIER\",\n                \"adjustmentValue\": 1.5\n              }\n            }\n          }\n        }\n      ]\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Update adjustment rules"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"success\": [\n    {\n      \"index\": 0,\n      \"rule\": {\n        \"ruleId\": \"example-rule-id\",\n        \"name\": \"Sample name\",\n        \"adProduct\": \"AMAZON_DSP\",\n        \"state\": \"ENABLED\",\n        \"status\": {\n          \"deliveryStatus\": \"DELIVERING\",\n          \"deliveryReasons\": []\n        },\n        \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n        \"lastUpdatedDateTime\": \"2025-01-01T00:00:00Z\",\n        \"expressionType\": \"DIMENSION_RULE_EXPRESSION\",\n        \"expression\": [\n          {\n            \"dimensionRuleExpression\": {\n              \"conditions\": {\n                \"criteriaCondition\": {\n                  \"criteriaJoinOperator\": \"AND\",\n                  \"criteria\": [\n                    {\n                      \"dimensionCriteria\": {\n                        \"dimensionJoinOperator\": \"AND\",\n                        \"dimensions\": [\n                          {\n                            \"dimensionType\": \"AD_FORMAT\",\n                            \"dimensionValues\": [\n                              \"DISPLAY\",\n                              \"VIDEO\"\n                            ],\n                            \"negative\": false\n                          }\n                        ]\n                      }\n                    }\n                  ]\n                }\n              },\n              \"actions\": {\n                \"valueAdjustment\": {\n                  \"adjustmentType\": \"MULTIPLIER\",\n                  \"adjustmentValue\": 1.5\n                }\n              }\n            }\n          }\n        ],\n        \"onRuleExpressionConflict\": \"ALL\"\n      }\n    }\n  ],\n  \"error\": []\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "SellingAccounts",
+          "item": [
+            {
+              "name": "List selling accounts",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/sellingAccounts",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "sellingAccounts"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"maxResults\": 100\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "List selling accounts"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/sellingAccounts",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "sellingAccounts"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"maxResults\": 100\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "List selling accounts"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"sellingAccounts\": []\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "SupplierAdProductPrices",
+          "item": [
+            {
+              "name": "Create supplier ad product price",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/supplierAdProductPrices/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "supplierAdProductPrices",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"supplierAdProductPrices\": [\n    {\n      \"supplierAdProductPriceDescription\": {}\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create supplier ad product price"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/supplierAdProductPrices/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "supplierAdProductPrices",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"supplierAdProductPrices\": [\n    {\n      \"supplierAdProductPriceDescription\": {}\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create supplier ad product price"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [],\n      \"index\": 0\n    }\n  ],\n  \"success\": [\n    {\n      \"index\": 0,\n      \"supplierAdProductPrice\": {}\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "SupplierAdProducts",
+          "item": [
+            {
+              "name": "Query supplier ad products",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/supplierAdProducts/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "supplierAdProducts",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"supplierIdFilter\": {\n    \"include\": [\n      \"Netflix\"\n    ]\n  },\n  \"supplierAdProductIdFilter\": {\n    \"include\": [\n      \"example-include\"\n    ]\n  },\n  \"maxResults\": 1\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query supplier ad products"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/supplierAdProducts/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "supplierAdProducts",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"supplierIdFilter\": {\n    \"include\": [\n      \"Netflix\"\n    ]\n  },\n  \"supplierAdProductIdFilter\": {\n    \"include\": [\n      \"example-include\"\n    ]\n  },\n  \"maxResults\": 1\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query supplier ad products"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"nextToken\": null,\n  \"supplierAdProducts\": [\n    {\n      \"constraints\": {\n        \"bookingConstraints\": {\n          \"range\": {\n            \"maxDateTime\": \"2026-12-31T23:59:59Z\",\n            \"minDateTime\": \"2026-05-01T00:00:00Z\"\n          }\n        },\n        \"budgetConstraints\": {\n          \"maximumBudget\": {\n            \"currencyCode\": \"USD\",\n            \"ruleValue\": null,\n            \"value\": 500000000.0\n          },\n          \"minimumBudget\": {\n            \"currencyCode\": \"USD\",\n            \"ruleValue\": null,\n            \"value\": 50000000.0\n          },\n          \"privateAuctionBaseCpm\": null,\n          \"programGuaranteedBaseCpm\": null\n        },\n        \"flightConstraints\": {\n          \"fixed\": null,\n          \"range\": {\n            \"maxDateTime\": \"2026-12-31T23:59:59Z\",\n            \"maxHours\": 4320,\n            \"minDateTime\": \"2026-05-01T00:00:00Z\",\n            \"minHours\": 72\n          }\n        },\n        \"frequencyConstraints\": {\n          \"fixed\": {\n            \"frequencyIntents\": [\n              {\n                \"eventCount\": 3,\n                \"eventMaxCount\": null,\n                \"eventType\": \"IMPRESSION\",\n                \"extraFrequencyCapImpressionTypes\": null,\n                \"frequencyTargetingSetting\": \"USER\",\n                \"timeCount\": 1,\n                \"timeUnit\": \"DAYS\"\n              }\n            ]\n          },\n          \"range\": {\n            \"maxCount\": 5,\n            \"minCount\": 1\n          },\n          \"supportsFrequencyIntent\": true\n        },\n        \"goalConstraints\": null,\n        \"shareOfVoiceConstraints\": {\n          \"fixed\": null,\n          \"range\": {\n            \"maxPercent\": 50.0,\n            \"minPercent\": 10.0,\n            \"percentIncrement\": 5.0\n          }\n        },\n        \"targetingConstraints\": {\n          \"fixed\": [\n            {\n              \"groupDetails\": null,\n              \"groupName\": \"Sample groupName\",\n              \"groupTargets\": [\n                {\n                  \"negative\": null,\n                  \"supplierTargetDetails\": {\n                    \"supplierAudienceTarget\": {\n                      \"groupId\": \"aud-group-1\",\n                      \"supplierTargetItemId\": null\n                    }\n                  },\n                  \"supplierTargetType\": \"AUDIENCE\"\n                }\n              ],\n              \"groupType\": null\n            },\n            {\n              \"groupDetails\": null,\n              \"groupName\": \"Sample groupName\",\n              \"groupTargets\": [\n                {\n                  \"negative\": null,\n                  \"supplierTargetDetails\": {\n                    \"supplierLocationTarget\": {\n                      \"supplierTargetItemId\": null\n                    }\n                  },\n                  \"supplierTargetType\": \"LOCATION_COUNTRY\"\n                }\n              ],\n              \"groupType\": null\n            }\n          ],\n          \"supplierTargetGroups\": [\n            {\n              \"groupConstraints\": [\n                {\n                  \"negative\": null,\n                  \"positive\": {\n                    \"maxValues\": 10,\n                    \"minValues\": 1\n                  },\n                  \"supplierTargetType\": \"AUDIENCE\"\n                }\n              ],\n              \"groupName\": \"Sample groupName\",\n              \"supplierTargetGroupConstraintDetails\": null,\n              \"supplierTargetGroupConstraintType\": null\n            },\n            {\n              \"groupConstraints\": [\n                {\n                  \"negative\": null,\n                  \"positive\": {\n                    \"maxValues\": 5,\n                    \"minValues\": 1\n                  },\n                  \"supplierTargetType\": \"LOCATION_COUNTRY\"\n                }\n              ],\n              \"groupName\": \"Sample groupName\",\n              \"supplierTargetGroupConstraintDetails\": null,\n              \"supplierTargetGroupConstraintType\": null\n            }\n          ]\n        }\n      },\n      \"countryConfigurations\": [\n        {\n          \"constraintsOverride\": null,\n          \"country\": \"US\",\n          \"creativeRequirementsOverride\": null,\n          \"currency\": \"USD\",\n          \"timezone\": \"AMERICA_NEW_YORK\"\n        }\n      ],\n      \"creativeRequirements\": [\n        {\n          \"creativeRequirement\": {\n            \"videoCreativeRequirements\": {\n              \"durationMs\": 30000,\n              \"size\": {\n                \"height\": 1080,\n                \"width\": 1920\n              }\n            }\n          },\n          \"inventoryType\": \"VIDEO\"\n        }\n      ],\n      \"customPublisherDescription\": null,\n      \"dealType\": \"PREFERRED\",\n      \"name\": \"Sample name\",\n      \"priceType\": \"FIXED_PRICE\",\n      \"supplierAdProductExtension\": null,\n      \"supplierAdProductId\": \"example-supplier-ad-product-id\",\n      \"supplierAdProductType\": \"Netflix\",\n      \"supplierId\": \"Netflix\",\n      \"supplierPublisherId\": null\n    }\n  ],\n  \"totalResults\": 1\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "SupplierProposalDestinations",
+          "item": [
+            {
+              "name": "Query supplier proposal destinations",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/supplierProposalDestinations/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "supplierProposalDestinations",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"maxResults\": 100,\n  \"supplierProposalDestinationNameFilter\": {\n    \"include\": [\n      \"net\"\n    ],\n    \"queryTermMatchType\": \"BROAD_MATCH\"\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query supplier proposal destinations"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/supplierProposalDestinations/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "supplierProposalDestinations",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"maxResults\": 100,\n  \"supplierProposalDestinationNameFilter\": {\n    \"include\": [\n      \"net\"\n    ],\n    \"queryTermMatchType\": \"BROAD_MATCH\"\n  }\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query supplier proposal destinations"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"nextToken\": null,\n  \"supplierProposalDestinations\": [],\n  \"totalResults\": 0\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "SupplierProposals",
+          "item": [
+            {
+              "name": "Create supplier proposal",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/supplierProposals/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "supplierProposals",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"supplierProposals\": [\n    {\n      \"name\": \"sample-name\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create supplier proposal"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/supplierProposals/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "supplierProposals",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"supplierProposals\": [\n    {\n      \"name\": \"sample-name\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create supplier proposal"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [],\n      \"index\": 0\n    }\n  ],\n  \"success\": [\n    {\n      \"index\": 0,\n      \"supplierProposal\": {}\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Query supplier proposal",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/supplierProposals/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "supplierProposals",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"advertiserAccountIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  },\n  \"countriesFilter\": {\n    \"include\": [\n      \"AD\"\n    ]\n  },\n  \"endDateTimeFilter\": {\n    \"include\": [\n      \"2025-01-01T00:00:00Z\"\n    ]\n  },\n  \"maxResults\": 1,\n  \"nameFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  },\n  \"nextToken\": \"sample-nextToken\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query supplier proposal"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/supplierProposals/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "supplierProposals",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"advertiserAccountIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  },\n  \"countriesFilter\": {\n    \"include\": [\n      \"AD\"\n    ]\n  },\n  \"endDateTimeFilter\": {\n    \"include\": [\n      \"2025-01-01T00:00:00Z\"\n    ]\n  },\n  \"maxResults\": 1,\n  \"nameFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  },\n  \"nextToken\": \"sample-nextToken\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query supplier proposal"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"nextToken\": \"sample-nextToken\",\n  \"supplierProposals\": [\n    {\n      \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n      \"lastUpdatedDateTime\": \"2025-01-01T00:00:00Z\",\n      \"name\": \"sample-name\",\n      \"status\": \"CANCELLED\",\n      \"supplierProposalId\": \"sample-supplierProposalId\",\n      \"version\": 0\n    }\n  ],\n  \"totalResults\": 0\n}"
+                }
+              ]
+            },
+            {
+              "name": "Update supplier proposal",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/update/supplierProposals/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "update",
+                    "supplierProposals",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"supplierProposals\": [\n    {\n      \"supplierProposalId\": \"sample-supplierProposalId\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update supplier proposal"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/update/supplierProposals/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "update",
+                        "supplierProposals",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"supplierProposals\": [\n    {\n      \"supplierProposalId\": \"sample-supplierProposalId\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Update supplier proposal"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [],\n      \"index\": 0\n    }\n  ],\n  \"success\": [\n    {\n      \"index\": 0,\n      \"supplierProposal\": {}\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "SupplierProposedDealForecasts",
+          "item": [
+            {
+              "name": "Create supplier proposed deal forecast",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/supplierProposedDealForecasts/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "supplierProposedDealForecasts",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"supplierProposedDealForecasts\": [\n    {\n      \"supplierProposedDealForecastDescription\": {}\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create supplier proposed deal forecast"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/supplierProposedDealForecasts/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "supplierProposedDealForecasts",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"supplierProposedDealForecasts\": [\n    {\n      \"supplierProposedDealForecastDescription\": {}\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create supplier proposed deal forecast"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [],\n      \"index\": 0\n    }\n  ],\n  \"success\": [\n    {\n      \"index\": 0,\n      \"supplierProposedDealForecast\": {}\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "SupplierProposedDealHistoricalVersions",
+          "item": [
+            {
+              "name": "Query supplier proposed deal historical versions",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/supplierProposedDealHistoricalVersions/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "supplierProposedDealHistoricalVersions",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"supplierProposalDestinationIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  },\n  \"supplierProposedDealIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query supplier proposed deal historical versions"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/supplierProposedDealHistoricalVersions/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "supplierProposedDealHistoricalVersions",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"supplierProposalDestinationIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  },\n  \"supplierProposedDealIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  }\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query supplier proposed deal historical versions"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"nextToken\": \"sample-nextToken\",\n  \"supplierProposedDealHistoricalVersions\": [\n    {\n      \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n      \"dealName\": \"sample-dealName\",\n      \"dealStatus\": \"APPROVED\",\n      \"dealType\": \"PREFERRED\",\n      \"endDateTime\": \"2025-01-01T00:00:00Z\",\n      \"lastUpdatedDateTime\": \"2025-01-01T00:00:00Z\",\n      \"startDateTime\": \"2025-01-01T00:00:00Z\",\n      \"supplierProposalId\": \"sample-supplierProposalId\",\n      \"supplierProposedDealHistoricalVersionId\": {},\n      \"terms\": {}\n    }\n  ],\n  \"totalResults\": 0\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "SupplierProposedDealRevisions",
+          "item": [
+            {
+              "name": "Create supplier proposed deal revision",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/supplierProposedDealRevisions/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "supplierProposedDealRevisions",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"supplierProposedDealRevisions\": [\n    {\n      \"supplierProposedDealId\": \"sample-supplierProposedDealId\",\n      \"supplierProposedDealRevisionDescription\": {}\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create supplier proposed deal revision"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/supplierProposedDealRevisions/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "supplierProposedDealRevisions",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"supplierProposedDealRevisions\": [\n    {\n      \"supplierProposedDealId\": \"sample-supplierProposedDealId\",\n      \"supplierProposedDealRevisionDescription\": {}\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create supplier proposed deal revision"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [],\n      \"index\": 0\n    }\n  ],\n  \"success\": [\n    {\n      \"index\": 0,\n      \"supplierProposedDealRevision\": {}\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Update supplier proposed deal revision",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/update/supplierProposedDealRevisions/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "update",
+                    "supplierProposedDealRevisions",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"supplierProposedDealRevisions\": [\n    {\n      \"supplierProposedDealRevisionDescription\": {}\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update supplier proposed deal revision"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/update/supplierProposedDealRevisions/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "update",
+                        "supplierProposedDealRevisions",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"supplierProposedDealRevisions\": [\n    {\n      \"supplierProposedDealRevisionDescription\": {}\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Update supplier proposed deal revision"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [],\n      \"index\": 0\n    }\n  ],\n  \"success\": [\n    {\n      \"index\": 0,\n      \"supplierProposedDealRevision\": {}\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "SupplierProposedDeals",
+          "item": [
+            {
+              "name": "Create supplier proposed deal",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/create/supplierProposedDeals/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "create",
+                    "supplierProposedDeals",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"supplierProposedDeals\": [\n    {\n      \"dealName\": \"sample-dealName\",\n      \"dealType\": \"PREFERRED\",\n      \"endDateTime\": \"2025-01-01T00:00:00Z\",\n      \"startDateTime\": \"2025-01-01T00:00:00Z\",\n      \"supplierProposalId\": \"sample-supplierProposalId\",\n      \"terms\": {}\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Create supplier proposed deal"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/create/supplierProposedDeals/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "create",
+                        "supplierProposedDeals",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"supplierProposedDeals\": [\n    {\n      \"dealName\": \"sample-dealName\",\n      \"dealType\": \"PREFERRED\",\n      \"endDateTime\": \"2025-01-01T00:00:00Z\",\n      \"startDateTime\": \"2025-01-01T00:00:00Z\",\n      \"supplierProposalId\": \"sample-supplierProposalId\",\n      \"terms\": {}\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Create supplier proposed deal"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [],\n      \"index\": 0\n    }\n  ],\n  \"success\": [\n    {\n      \"index\": 0,\n      \"supplierProposedDeal\": {}\n    }\n  ]\n}"
+                }
+              ]
+            },
+            {
+              "name": "Query supplier proposed deals",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/supplierProposedDeals/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "supplierProposedDeals",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"advertiserAccountIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  },\n  \"advertisingDealIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  },\n  \"dealNameFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  },\n  \"dealStatusFilter\": {\n    \"include\": [\n      \"APPROVED\"\n    ]\n  },\n  \"dealTypeFilter\": {\n    \"include\": [\n      \"PREFERRED\"\n    ]\n  },\n  \"endDateTimeFilter\": {\n    \"include\": [\n      \"2025-01-01T00:00:00Z\"\n    ]\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query supplier proposed deals"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/supplierProposedDeals/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "supplierProposedDeals",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"advertiserAccountIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  },\n  \"advertisingDealIdFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  },\n  \"dealNameFilter\": {\n    \"include\": [\n      \"sample-include\"\n    ]\n  },\n  \"dealStatusFilter\": {\n    \"include\": [\n      \"APPROVED\"\n    ]\n  },\n  \"dealTypeFilter\": {\n    \"include\": [\n      \"PREFERRED\"\n    ]\n  },\n  \"endDateTimeFilter\": {\n    \"include\": [\n      \"2025-01-01T00:00:00Z\"\n    ]\n  }\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query supplier proposed deals"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"nextToken\": \"sample-nextToken\",\n  \"supplierProposedDeals\": [\n    {\n      \"creationDateTime\": \"2025-01-01T00:00:00Z\",\n      \"dealName\": \"sample-dealName\",\n      \"dealStatus\": \"APPROVED\",\n      \"dealType\": \"PREFERRED\",\n      \"endDateTime\": \"2025-01-01T00:00:00Z\",\n      \"lastUpdatedDateTime\": \"2025-01-01T00:00:00Z\",\n      \"startDateTime\": \"2025-01-01T00:00:00Z\",\n      \"supplierProposalId\": \"sample-supplierProposalId\",\n      \"supplierProposedDealId\": \"sample-supplierProposedDealId\",\n      \"terms\": {}\n    }\n  ],\n  \"totalResults\": 0\n}"
+                }
+              ]
+            },
+            {
+              "name": "Update supplier proposed deal",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/update/supplierProposedDeals/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "update",
+                    "supplierProposedDeals",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"supplierProposedDeals\": [\n    {\n      \"supplierProposedDealId\": \"sample-supplierProposedDealId\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update supplier proposed deal"
+              },
+              "response": [
+                {
+                  "name": "Example 207",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/update/supplierProposedDeals/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "update",
+                        "supplierProposedDeals",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"supplierProposedDeals\": [\n    {\n      \"supplierProposedDealId\": \"sample-supplierProposedDealId\"\n    }\n  ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Update supplier proposed deal"
+                  },
+                  "status": "OK",
+                  "code": 207,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"error\": [\n    {\n      \"errors\": [],\n      \"index\": 0\n    }\n  ],\n  \"success\": [\n    {\n      \"index\": 0,\n      \"supplierProposedDeal\": {}\n    }\n  ]\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "SupplierPublishers",
+          "item": [
+            {
+              "name": "Query supplier publishers",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-Manager-AccountId",
+                    "value": "{{manager_account_id}}",
+                    "type": "text",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/supplierPublishers/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "supplierPublishers",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"supplierPublisherTypeFilter\": {\n    \"include\": [\n      \"AMAZON_PUBLISHER_CLOUD\"\n    ]\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Query supplier publishers"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-Manager-AccountId",
+                        "value": "{{manager_account_id}}",
+                        "type": "text",
+                        "disabled": true
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/supplierPublishers/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "supplierPublishers",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"supplierPublisherTypeFilter\": {\n    \"include\": [\n      \"AMAZON_PUBLISHER_CLOUD\"\n    ]\n  }\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Query supplier publishers"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"nextToken\": \"sample-nextToken\",\n  \"supplierPublishers\": [\n    {\n      \"supplierPublisherId\": \"sample-supplierPublisherId\"\n    }\n  ],\n  \"totalResults\": 0\n}"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "SupplierTargetItems",
+          "item": [
+            {
+              "name": "Fetch supplier target items",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{access_token}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-AccountId",
+                    "value": "{{accountId}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Amazon-Ads-ClientId",
+                    "value": "{{client_id}}",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{api_url}}/adsApi/v1/query/supplierTargetItems/dsp",
+                  "host": [
+                    "{{api_url}}"
+                  ],
+                  "path": [
+                    "adsApi",
+                    "v1",
+                    "query",
+                    "supplierTargetItems",
+                    "dsp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"supplierTargetTypeFilter\": {\n    \"include\": [\n      \"AUDIENCE\"\n    ]\n  },\n  \"supplierIdFilter\": {\n    \"include\": [\n      \"EXAMPLEENTITYID00000\"\n    ]\n  },\n  \"supplierAdProductIdFilter\": {\n    \"include\": [\n      \"EXAMPLEENTITYID00000\"\n    ]\n  },\n  \"countriesFilter\": {\n    \"include\": [\n      \"US\"\n    ]\n  },\n  \"maxResults\": 10\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Fetch supplier target items"
+              },
+              "response": [
+                {
+                  "name": "Example 200",
+                  "originalRequest": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{access_token}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-AccountId",
+                        "value": "{{accountId}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Amazon-Ads-ClientId",
+                        "value": "{{client_id}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      },
+                      {
+                        "key": "Accept",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{api_url}}/adsApi/v1/query/supplierTargetItems/dsp",
+                      "host": [
+                        "{{api_url}}"
+                      ],
+                      "path": [
+                        "adsApi",
+                        "v1",
+                        "query",
+                        "supplierTargetItems",
+                        "dsp"
+                      ]
+                    },
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"supplierTargetTypeFilter\": {\n    \"include\": [\n      \"AUDIENCE\"\n    ]\n  },\n  \"supplierIdFilter\": {\n    \"include\": [\n      \"EXAMPLEENTITYID00000\"\n    ]\n  },\n  \"supplierAdProductIdFilter\": {\n    \"include\": [\n      \"EXAMPLEENTITYID00000\"\n    ]\n  },\n  \"countriesFilter\": {\n    \"include\": [\n      \"US\"\n    ]\n  },\n  \"maxResults\": 10\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "description": "Fetch supplier target items"
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "_postman_previewlanguage": "json",
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "application/json"
+                    }
+                  ],
+                  "body": "{\n  \"nextToken\": null,\n  \"supplierTargetItems\": [],\n  \"totalResults\": 0\n}"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "// This pre-request script handles access token freshness for requests in this collection (exception: explicit requests located in the Auth folder). ",
+          "// See the collection documentation for initial setup instructions. ",
+          "// For information about authorization in the Amazon Ads API, visit https://advertising.amazon.com/API/docs/en-us/concepts/authorization/overview",
+          "",
+          "// Ignore script for explicit auth requests",
+          "if (pm.info.requestName.startsWith(\"Access token\") || pm.info.requestName.startsWith(\"Auth grant\")) {",
+          "    return false",
+          "}",
+          "",
+          "// Check presence of refresh token",
+          "if (pm.environment.get('refresh_token')) {",
+          "",
+          "    // Check expiry of current access token",
+          "    if (Date.now() > pm.environment.get('token_expires_at')) {",
+          "",
+          "        // Construct refresh token request",
+          "        // Information: https://advertising.amazon.com/API/docs/en-us/concepts/authorization/access-tokens#generating-an-access-token-using-a-refresh-token",
+          "        const refreshRequest = {",
+          "            url: pm.environment.get('token_url'),",
+          "            method: \"POST\",",
+          "            header: {",
+          "                \"Content-Type\": \"application/x-www-form-urlencoded\"",
+          "            },",
+          "            body: {",
+          "                mode: \"urlencoded\",",
+          "                urlencoded: [",
+          "                    'grant_type=refresh_token',",
+          "                    `client_id=${pm.environment.get('client_id')}`,",
+          "                    `refresh_token=${pm.environment.get('refresh_token')}`,",
+          "                    `client_secret=${pm.environment.get('client_secret')}`",
+          "                ]",
+          "            }",
+          "        }",
+          "",
+          "        pm.sendRequest(refreshRequest, (error, response) => {",
+          "            if (error) {",
+          "                console.log(error)",
+          "            } else {",
+          "                if (response.code === 200){",
+          "                    const res = response.json();",
+          "                    const newExpiry = Date.now() + (res.expires_in * 1000) - 10000",
+          "                    console.log('Access token retrieved.')",
+          "                    console.log(`Expires at: ${new Date(newExpiry)}`)",
+          "",
+          "                    // set access_token, refresh_token, and token_expires_at in Postman environment",
+          "                    postman.setEnvironmentVariable(\"access_token\", res.access_token);",
+          "                    postman.setEnvironmentVariable(\"refresh_token\", res.refresh_token);",
+          "                    postman.setEnvironmentVariable(\"token_expires_at\", newExpiry)",
+          "                } else {",
+          "                    console.log(\"Authorization failed.\")",
+          "                    console.log(response)",
+          "                }",
+          "            }",
+          "        })",
+          "    }",
+          "} else {",
+          "    console.log(\"No refresh token found in environment. See documentation for information on auth setup.\")",
+          "}",
+          "",
+          "/**Add custom header containing the collection version to all collection requests*/",
+          "pm.request.headers.add({key: 'Postman-Collection', value: 'Amazon-Ads-API-v1.6'}) "
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "// Generic response assertions for Unified API requests.",
+          "// Skips the explicit Auth token/grant requests (handled separately).",
+          "var _n = pm.info.requestName || '';",
+          "if (!_n.startsWith('Auth grant') && !_n.startsWith('Access token')) {",
+          "    pm.test('Status code is 2xx', function () { pm.response.to.be.success; });",
+          "    pm.test('Response body is JSON', function () { pm.response.to.be.json; });",
+          "    pm.test('Response time is under 5000ms', function () {",
+          "        pm.expect(pm.response.responseTime).to.be.below(5000);",
+          "    });",
+          "}"
+        ]
+      }
+    }
+  ]
+}

--- a/postman/Amazon_Ads_Unified_API_Environment.postman_environment.json
+++ b/postman/Amazon_Ads_Unified_API_Environment.postman_environment.json
@@ -1,0 +1,114 @@
+{
+  "name": "Amazon Ads Unified API Environment",
+  "values": [
+    {
+      "key": "client_id",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "client_secret",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "permission_scope",
+      "value": "advertising::campaign_management",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "redirect_uri",
+      "value": "https://amazon.com",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "access_token",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "refresh_token",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "token_expires_at",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "profileId",
+      "value": "",
+      "type": "any",
+      "enabled": true
+    },
+    {
+      "key": "auth_grant_url",
+      "value": "https://www.amazon.com/ap/oa",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "token_url",
+      "value": "https://api.amazon.com/auth/o2/token",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "api_url",
+      "value": "https://advertising-api.amazon.com",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "dspAccountId",
+      "value": "",
+      "type": "any",
+      "enabled": true
+    },
+    {
+      "key": "manager_account_id",
+      "value": "",
+      "type": "any",
+      "enabled": true
+    },
+    {
+      "key": "accountId",
+      "value": "",
+      "type": "any",
+      "enabled": true,
+      "description": "Amazon Ads Advertiser Account id; sent as the Amazon-Ads-AccountId header."
+    },
+    {
+      "key": "api_url_na",
+      "value": "https://advertising-api.amazon.com",
+      "type": "default",
+      "enabled": true,
+      "description": "North America base URL"
+    },
+    {
+      "key": "api_url_eu",
+      "value": "https://advertising-api-eu.amazon.com",
+      "type": "default",
+      "enabled": true,
+      "description": "Europe base URL"
+    },
+    {
+      "key": "api_url_fe",
+      "value": "https://advertising-api-fe.amazon.com",
+      "type": "default",
+      "enabled": true,
+      "description": "Far East base URL"
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2022-05-24T20:37:06.442Z",
+  "_postman_exported_using": "Postman/9.16.0"
+}

--- a/postman/README.md
+++ b/postman/README.md
@@ -1,14 +1,35 @@
-# Amazon Ads API Postman collection
+# Amazon Ads API Postman collections
 
-[Postman](https://www.postman.com/) is a tool that allows developers to make API calls using a user interface. Postman can also store variables and perform basic automations that simplify API testing. 
+[Postman](https://www.postman.com/) is a tool that allows developers to make API calls using a user interface. Postman can also store variables and perform basic automations that simplify API testing.
 
-Amazon Ads provides a Postman collection that includes commonly used API endpoints. The collection also includes pre- and post-request scripts to automate management of auth credentials.
+This folder contains **two separate Postman collections**, each with its own environment file. Pick the one that matches the interface you are building against.
 
 Visit the [Amazon Ads advanced tools center](https://advertising.amazon.com/API/docs/en-us/) for additional API documentation.
 
-## Currently supported
+## Which collection should I use?
 
-The Amazon Ads API Postman collection currently supports the following features:
+| | **Amazon Ads API** | **Amazon Ads Unified API** |
+|---|---|---|
+| Collection file | `Amazon_Ads_API.postman_collection.json` | `Amazon_Ads_Unified_API.postman_collection.json` |
+| Environment file | `Amazon_Ads_API_Environment.postman_environment.json` | `Amazon_Ads_Unified_API_Environment.postman_environment.json` |
+| Interface | Per-service endpoints (`/sp/campaigns`, `/reporting/reports`, and so on) | Single unified interface under `/adsApi/v1` |
+| Account context | `Amazon-Advertising-API-Scope: {{profileId}}` | `Amazon-Ads-AccountId: {{accountId}}` |
+| Best for | Existing integrations, service-specific workflows | New integrations that want one consistent request pattern across ad products |
+
+Both collections share the same OAuth setup and the same Auth folder behavior, so credentials you already have work for either one. You can import both and switch environments as needed.
+
+---
+
+## 1. Amazon Ads API collection
+
+The original collection, organized by service. It includes commonly used endpoints plus pre- and post-request scripts that automate management of auth credentials.
+
+**Files**
+
+- `Amazon_Ads_API.postman_collection.json`
+- `Amazon_Ads_API_Environment.postman_environment.json`
+
+**Currently supported**
 
 - Authentication
 - GET profiles
@@ -19,11 +40,11 @@ The Amazon Ads API Postman collection currently supports the following features:
     - Version 3
     - Version 2
 - DSP reporting
-- Sponsored ads snapshots 
+- Sponsored ads snapshots
 - Test accounts
 - Amazon Marketing Stream
 - Amazon Marketing Cloud
-- Product metadata 
+- Product metadata
 - Sponsored ads budget usage
 - Sponsored ads budget rules
 - Sponsored Brands campaigns, ads, and ad groups
@@ -35,14 +56,50 @@ The Amazon Ads API Postman collection currently supports the following features:
 - Exports
 - Partner opportunities
 
+---
+
+## 2. Amazon Ads Unified API collection
+
+A collection for the Amazon Ads API unified interface (`/adsApi/v1`). Operations are grouped by resource rather than by ad product, and each request includes an example body where applicable.
+
+**Files**
+
+- `Amazon_Ads_Unified_API.postman_collection.json`
+- `Amazon_Ads_Unified_API_Environment.postman_environment.json`
+
+**Structure**
+
+- **Auth** — auth grant login, access token from auth grant code, access token from refresh token
+- **Unified API — Prod (3P)** — generally available resources, including Campaigns, AdGroups, Ads, Targets, AdAssociations, AdExtensions, AdvertisingDeals, AdvertisingDealTargets, Brand Stores (stores, pages, editions, publish versions), Commitments, CommitmentSpends, CampaignForecasts, Recommendations, RecommendationTypes, GeoLocations, LocationIndexes, BrandedKeywordsPricings, ReservedTargetPricings, and KeywordReservationValidations
+- **Unified API — Beta** — preview resources, including Reports, Events, Rules, RuleLinks, Labels, AdvertiserAccounts, ManagerAccounts, SellingAccounts, AccountCombinationInvitations, BuyerSeats, Publishers, InventoryGroups, deal planning and access resources, supplier proposal and deal resources, and linear TV forecasting resources
+
+Beta resources may change without notice. Treat them as unstable and avoid depending on them in production integrations.
+
+**Environment notes**
+
+This environment adds a few variables that the per-service environment does not use:
+
+- `accountId` — sent as the `Amazon-Ads-AccountId` header on unified requests
+- `api_url_na`, `api_url_eu`, `api_url_fe` — regional endpoints; copy the one you need into `api_url`
+
+---
+
 ## Setup
 
-To use this collection, you will need credentials for the Amazon Ads API. For information about acquiring credentials, see the [onboarding overview for the Amazon Ads API](https://advertising.amazon.com/API/docs/en-us/setting-up/overview).
+To use either collection, you will need credentials for the Amazon Ads API. For information about acquiring credentials, see the [onboarding overview for the Amazon Ads API](https://advertising.amazon.com/API/docs/en-us/setting-up/overview).
 
-Find setup instructions in the Amazon Ads advanced tools center for:
+1. Import the collection file and its matching environment file into Postman.
+2. Select the imported environment.
+3. Set `client_id` and `client_secret`.
+4. Run the requests in the **Auth** folder to obtain an access token and refresh token.
+5. Set the account context: `profileId` for the Amazon Ads API collection, or `accountId` for the Unified API collection.
+
+Store `client_secret`, `access_token`, and `refresh_token` as Postman **secret** variable types, and keep them out of any exported files you share or commit.
+
+Find detailed setup instructions in the Amazon Ads advanced tools center for:
 
 - [New users of the Amazon Ads API](https://advertising.amazon.com/API/docs/en-us/getting-started/using-postman-collection)
-- [Users with an existing refresh token](https://advertising.amazon.com/API/docs/en-us/tutorials/postman) 
+- [Users with an existing refresh token](https://advertising.amazon.com/API/docs/en-us/tutorials/postman)
 
 You can also view a [video walkthrough of the collection setup steps on YouTube](https://www.youtube.com/watch?v=SWqOPN33phw).
 
@@ -50,4 +107,4 @@ You can also view a [video walkthrough of the collection setup steps on YouTube]
 
 For technical support for the Amazon Ads API, see [Technical support](https://advertising.amazon.com/API/docs/en-us/info/support) in the Amazon Ads advanced tools center.
 
-To report a bug or suggest an improvement relating to this collection or the documentation, [create an issue](https://github.com/amzn/ads-advanced-tools-docs/issues/new/choose).
+To report a bug or suggest an improvement relating to these collections or the documentation, [create an issue](https://github.com/amzn/ads-advanced-tools-docs/issues/new/choose). Please mention which collection the issue applies to.


### PR DESCRIPTION
## Summary

Adds a Postman collection for the Amazon Ads API unified interface (`/adsApi/v1`) alongside the existing per-service collection, and restructures `postman/README.md` so readers can tell the two apart.

**New files**

- `postman/Amazon_Ads_Unified_API.postman_collection.json` — 118 requests: an `Auth` folder, 22 generally available resources under `Unified API — Prod (3P)`, and 32 preview resources under `Unified API — Beta`. Operations are grouped by resource rather than by ad product, with example bodies where applicable.
- `postman/Amazon_Ads_Unified_API_Environment.postman_environment.json` — matching environment. Same OAuth variables as the existing environment, plus `accountId` (sent as the `Amazon-Ads-AccountId` header) and `api_url_na` / `api_url_eu` / `api_url_fe`.

**README changes**

`postman/README.md` previously described a single collection. It now has:

- A comparison table up front (collection file, environment file, interface style, account-context header, and what each is best for) so a reader can pick in one glance.
- A section per collection, each paired with its environment file. The existing supported-features list for the Amazon Ads API collection is unchanged.
- A note that beta resources may change without notice, since roughly half the unified surface sits there.
- A shared setup section, since both collections use the same OAuth flow, with the account-context step branching on `profileId` versus `accountId`.

Root `README.md`: "Postman collection" to "Postman collections" in the contents list.

## Testing

- Both collection files and both environment files parse as valid JSON.
- Collection and folder structure described in the README was read from the collection file itself, not assumed.
- Confirmed `client_id`, `client_secret`, `access_token`, and `refresh_token` in the new environment are empty and typed `secret`, and that no access tokens or client IDs appear anywhere in the new files.

Branched off the latest `upstream/main` (`a722a30`), so this applies cleanly. No existing collection or environment file is modified.
