### PR TITLE
correct Data Type Encoding table to match customData validation

### DIFF
--- a/custom-attributes-events-apis/docs/custom_attributes_guide.md
+++ b/custom-attributes-events-apis/docs/custom_attributes_guide.md
@@ -25,14 +25,16 @@ For the full conceptual guide and use case explanations, see the companion blog 
 - Keep names descriptive but concise
 
 ### Data Type Encoding
-All values are sent as strings regardless of their semantic type:
+`value` is always sent as a string, but `dataType` must be one of `STRING`, `INTEGER`, or
+`TIMESTAMP`, and `value` accepts only letters, numbers, and underscores, so decimal points
+are rejected:
 
 | Semantic Type | dataType Field | Value Format |
 |---------------|---------------|--------------|
 | Text | `STRING` | `"premium"` |
-| Number | `STRING` | `"49.99"` |
+| Decimal number | `INTEGER` | Scale to an integer unit such as cents: `"4999"` for $49.99 |
 | Boolean | `STRING` | `"true"` / `"false"` |
-| Integer | `STRING` | `"12"` |
+| Integer | `INTEGER` | `"12"` |
 
 ### Reserved Attributes
 


### PR DESCRIPTION
The Data Type Encoding table in `custom-attributes-events-apis/docs/custom_attributes_guide.md` tells readers to send numbers as `dataType: STRING` with a decimal value like `"49.99"`. The payload builder shipped beside it rejects that.

`send_event.py` applies `VALID_ATTRIBUTE_PATTERN = ^[A-Za-z0-9_]+$` (line 46) to `customData.value` (line 152), so the decimal point fails:

```
ValueError: Invalid custom attribute value '49.99' for 'price'. Only letters, numbers, and underscores are allowed.
```

The rest of the component already has this right. `README.md` says values take only letters, numbers and underscores, and to use cents as integers; the comment at `send_event.py:45` says `"49.99"` will be rejected; the example scripts use `INTEGER` for numeric attributes. The table is the only place that disagrees.

This also names `TIMESTAMP`, which the table omitted, with no value format because the component ships no example of one. Text and Boolean were already correct.

Verified by calling `build_event_payload` both ways: `STRING` / `"49.99"` raises the error above, `INTEGER` / `"4999"` returns the payload. Local validation only; I have no credentials for the live API.

Drafted with AI assistance. I ran the reproduction and read the validator myself.
